### PR TITLE
Mininet prefix

### DIFF
--- a/util/install.sh
+++ b/util/install.sh
@@ -15,8 +15,8 @@ if [ -z $MININET_PREFIX ]; then
 fi
 
 if [ ! -d $MININET_PREFIX ]; then
-  echo "$MININET_PREFIX: is not a directory."
-  exit 1
+    echo "$MININET_PREFIX: is not a directory."
+    exit 1
 fi
 
 echo "Using $MININET_PREFIX as mininet's install directory."


### PR DESCRIPTION
Hi all, 

This branch adds the MININET_PREFIX env variable for the util/install.sh script. The env variable determines the prefix for mininet installation. The default prefix is the parent directory of where mininet is installed (e.g., if mininet is install in /home/soheil/test/mininet, /home/soheil/test is the default MININET_PREFIX).

I'd like to request a pull for this branch into the main repo.

Thanks so much,
Soheil
