### PR TITLE
Ensure that any build environment compiler flags are observed

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,7 +48,7 @@ mn.1: $(MN)
 	--no-discard-stderr $< -o $@
 
 mnexec: mnexec.c $(MN) mininet/net.py
-	cc -DVERSION=\"`$(MN) --version`\" $< -o $@
+	cc $(CFLAGS) $(LDFLAGS) -DVERSION=\"`PYTHONPATH=. $(MN) --version`\" $< -o $@
 
 mnexec.1: mnexec
 	help2man -N -n "execution utility for Mininet." \


### PR DESCRIPTION
When we build packages in Ubuntu, debhelper automatically provides default compiler flags - this patch ensures that mininet will use them

It also makes the mn --version call in the same target work.
