### PR TITLE
Adapt mininet to OVS 1.7.1 kernel module

### DIFF
--- a/mininet/clean.py
+++ b/mininet/clean.py
@@ -27,7 +27,7 @@ def cleanup():
     info("*** Removing excess controllers/ofprotocols/ofdatapaths/pings/noxes"
          "\n")
     zombies = 'controller ofprotocol ofdatapath ping nox_core lt-nox_core '
-    zombies += 'ovs-openflowd udpbwtest'
+    zombies += 'ovs-openflowd udpbwtest ovsdb-server ovs-vswitchd'
     # Note: real zombie processes can't actually be killed, since they
     # are already (un)dead. Then again,
     # you can't connect to them either, so they're mostly harmless.

--- a/mininet/moduledeps.py
+++ b/mininet/moduledeps.py
@@ -19,7 +19,7 @@ def modprobe( mod ):
     return quietRun( [ 'modprobe', mod ] )
 
 OF_KMOD = 'ofdatapath'
-OVS_KMOD = 'openvswitch_mod'
+OVS_KMOD = 'openvswitch'
 TUN = 'tun'
 
 def moduleDeps( subtract=None, add=None ):

--- a/util/install.sh
+++ b/util/install.sh
@@ -52,10 +52,10 @@ KERNEL_IMAGE_OLD=linux-image-2.6.26-2-686
 
 DRIVERS_DIR=/lib/modules/${KERNEL_NAME}/kernel/drivers/net
 
-OVS_RELEASE=v1.2.2
+OVS_RELEASE=v1.7.1
 OVS_SRC=~/openvswitch
 OVS_BUILD=$OVS_SRC/build-$KERNEL_NAME
-OVS_KMODS=($OVS_BUILD/datapath/linux/{openvswitch_mod.ko,brcompat_mod.ko})
+OVS_KMODS=($OVS_BUILD/datapath/linux/{openvswitch.ko,brcompat.ko})
 
 function kernel {
     echo "Install Mininet-compatible kernel if necessary"
@@ -228,8 +228,8 @@ function ovs {
     ../configure $opts
     make
     sudo make install
-	# openflowd is deprecated, but for now copy it in
-	sudo cp tests/test-openflowd /usr/local/bin/ovs-openflowd
+    mkdir -p /usr/local/etc/openvswitch
+    ovsdb-tool create /usr/local/etc/openvswitch/conf.db.bak vswitchd/vswitch.ovsschema
 }
 
 # Install NOX with tutorial files


### PR DESCRIPTION
Modification of  the code in mininet to be compatible with the latest version of OpenVSwitch kernel module OVS 1.7.1.
Now the calls uses ovs-vsctl, ovs-vswitchd and ovsdb-server
