### PR TITLE
Adjust numbering of TC qdisc's to support switch-based QoS

### DIFF
--- a/mininet/link.py
+++ b/mininet/link.py
@@ -247,7 +247,7 @@ class TCIntf( Intf ):
                 cmds = [ '%s qdisc add dev %s ' + parent +
                          ' handle 10: netem ' +
                           netemargs ]
-                parent = ' parent 10: '
+                parent = ' parent 10:1 '
         return cmds, parent
 
     def tc( self, cmd, tc='tc' ):


### PR DESCRIPTION
hi,

this patch adjusts the major numbers uses by Mininet's qdiscs to allow the new link emulation features to be used in combination with an unmodified Open vSwitch or reference switch's support for QoS. without this patch, Mininet's tc numbers and the switch's tc numbers conflict.

using this approach, the top of the switch's hierarchy can sit at the bottom of a tc hierarchy created by mininet.

I have a modified version of OVSSwitch which works nicely with this patch:
https://github.com/brownsys/pane-demo-vm/blob/master/demos/PaneDemoUtil.py#L39

let me know if you'd like that as well.

cheers,
Andrew
