### PR TITLE
add host option: default_gw

### DIFF
--- a/mininet/node.py
+++ b/mininet/node.py
@@ -561,7 +561,7 @@ class Host( Node ):
             intf = self.defaultIntf()
         return self.cmd( 'route add default gw', default_gw, intf )
 
-    def config( self, default_gw, **params ):
+    def config( self, default_gw = None, **params ):
         r = super( Host, self ).config( **params )
 
         self.setParam( r, 'setDefaultGateway', default_gw=default_gw )


### PR DESCRIPTION
It seems like others need a feature similar to this as well:
https://mailman.stanford.edu/pipermail/mininet-discuss/2013-January/001553.html

For me it's logical to place the new setDefaultGateway under Host, but  setHostRoute is a method of Node, so I'm a bit confused.

BTW,  are these configuration options documented somewhere?
