### PR TITLE
tools/install.sh: catch up oftest change

### DIFF
--- a/util/install.sh
+++ b/util/install.sh
@@ -395,9 +395,6 @@ function oftest {
     # Install oftest:
     cd ~/
     git clone git://github.com/floodlight/oftest
-    cd oftest
-    cd tools/munger
-    sudo make install
 }
 
 # Install cbench


### PR DESCRIPTION
Since oftest removed tools/munger directory, install.sh fails as follows

> mininet/util/install.sh: line 399: cd: tools/mnuger: No such file or directory

oftest change set

> commit be8503a69d609d0aee844a91f3f5d66f4e2666c7
> Author: Rich Lane rlane@bigswitch.com
> Date:   Tue Mar 12 10:16:33 2013 -0700
> 
> ```
> remove pylibopenflow tools
> ```

Signed-off-by: Isaku Yamahata yamahata@valinux.co.jp
