### PR TITLE
(Pending) support QoS in OVS within Mininet's TCLinks

### DIFF
--- a/mininet/node.py
+++ b/mininet/node.py
@@ -1091,9 +1091,13 @@ class OVSBaseQosSwitch( OVSSwitch ):
                       ' -- --id=@default create Queue other-config:min-rate=1' )
             # Reset Mininet's configuration
             res = intf.config( **intf.params )
-            parent = res['parent']
+
+            if res is None: # link may not have TC parameters
+                return
+
             # Re-add qdisc, root, and default classes OVS created, but with
             # new parent, as setup by Mininet's TCIntf
+            parent = res['parent']
             intf.tc( "%s qdisc add dev %s " + parent +
                      " handle 1: " + self.qosType + " default 1" )
             intf.tc( "%s class add dev %s classid 1:0xfffe parent 1: " +


### PR DESCRIPTION
hi,

this pull request introduces two new switch classes: OVSHtbQosSwitch and OVSHfscQosSwitch which allow one to use Open vSwitch's HTB or HFSC QoS support as well as Mininet's TCLink / TCIntf classes. By using one of these two switch classes, a Linux tc hierarchy is pre-created for Open vSwitch _under_ the TCLink / TCIntf hierarchy. Future Open vSwitch QoS calls then create new queues at an appropriate point in the hierarchy.

Andrew
