### PR TITLE
tiny fix to vm script

### DIFF
--- a/util/vm/install-mininet-vm.sh
+++ b/util/vm/install-mininet-vm.sh
@@ -31,10 +31,4 @@ time mininet/util/install.sh
 #if ! grep NOX_CORE_DIR .bashrc; then
 #  echo "export NOX_CORE_DIR=~/noxcore/build/src/" >> .bashrc
 #fi
-cat <<EOF
-You may need to reboot and then:
-sudo dpkg-reconfigure openvswitch-datapath-dkms
-sudo service openvswitch-switch start
-EOF
-
 


### PR DESCRIPTION
dead-simple fix. I was building my own script to create VM's for mininet and realized that "echo << EOF" should be "cat << EOF" ... just thought it might be helpful for anyone else looking at this script. :-)
