### PR TITLE
node: Allow OVSSwitch to run in userspace mode

### DIFF
--- a/mininet/node.py
+++ b/mininet/node.py
@@ -896,12 +896,14 @@ class OVSLegacyKernelSwitch( Switch ):
 class OVSSwitch( Switch ):
     "Open vSwitch switch. Depends on ovs-vsctl."
 
-    def __init__( self, name, failMode='secure', **params ):
+    def __init__( self, name, failMode='secure', datapath='kernel', **params ):
         """Init.
            name: name for switch
-           failMode: controller loss behavior (secure|open)"""
+           failMode: controller loss behavior (secure|open)
+           datapath: userspace or kernel mode (kernel|user)"""
         Switch.__init__( self, name, **params )
         self.failMode = failMode
+        self.datapath = datapath
 
     @classmethod
     def setup( cls ):
@@ -956,6 +958,8 @@ class OVSSwitch( Switch ):
         # Annoyingly, --if-exists option seems not to work
         self.cmd( 'ovs-vsctl del-br', self )
         self.cmd( 'ovs-vsctl add-br', self )
+        if self.datapath == 'user':
+            self.cmd( 'ovs-vsctl set bridge', self,'datapath_type=netdev' )
         self.cmd( 'ovs-vsctl -- set Bridge', self,
                   'other_config:datapath-id=' + self.dpid )
         self.cmd( 'ovs-vsctl set-fail-mode', self, self.failMode )


### PR DESCRIPTION
This adds a datapath parameter to OVSSwitch which allows one to tell OVS to
run in userspace mode rather than kernel mode.  From the commandline, this
is --switch=ovsk,datapath=user.

Note that this makes "ovsk" and the OVSKernelSwitch alias misnomers.  Since
the default behavior is still kernel mode, this is hopefully harmless.

This is the second version of this patch, which changes the argument name
and values according to Bob's suggestion.
