### PR TITLE
node: Make OVS switches reconnect quickly

### DIFF
--- a/mininet/node.py
+++ b/mininet/node.py
@@ -968,6 +968,19 @@ class OVSSwitch( Switch ):
         if self.listenPort:
             clist += ' ptcp:%s' % self.listenPort
         self.cmd( 'ovs-vsctl set-controller', self, clist )
+        # Set controllers to reconnect quickly
+        controllers = self.cmd( 'ovs-vsctl --columns=controller find Bridge '
+                                'name=' + str(self) ).split(':',2)[-1].strip()
+
+        if controllers.startswith('[') and controllers.endswith(']'):
+            controllers = [c.strip() for c in controllers[1:-1].split(',')]
+            for uuid in controllers:
+                if uuid.count('-') != 4:
+                    # Doesn't look like a UUID
+                    continue
+                uuid = uuid.strip()
+                self.cmd( 'ovs-vsctl set Controller', uuid,
+                          'max_backoff=1000' )
 
     def stop( self ):
         "Terminate OVS switch."


### PR DESCRIPTION
Ordinarily, OVS switches back off when they can't reach their controllers.
Under the type of scenarios where Mininet is used, I think this is
probably just inconvenient.  This patch sets controllers to attempt to
reconnect every second.
