### PR TITLE
Fix issue with mountCgroups not recognizing mounted cgroup

### DIFF
--- a/mininet/util.py
+++ b/mininet/util.py
@@ -363,13 +363,13 @@ def fixLimits():
 
 def mountCgroups():
     "Make sure cgroups file system is mounted"
-    mounts = quietRun( 'mount' )
+    mounts = quietRun( 'cat /proc/mounts' )
     cgdir = '/sys/fs/cgroup'
     csdir = cgdir + '/cpuset'
-    if ('cgroup on %s' % cgdir not in mounts and
-            'cgroups on %s' % cgdir not in mounts):
+    if ('cgroup %s' % cgdir not in mounts and
+            'cgroups %s' % cgdir not in mounts):
         raise Exception( "cgroups not mounted on " + cgdir )
-    if 'cpuset on %s' % csdir not in mounts:
+    if 'cpuset %s' % csdir not in mounts:
         errRun( 'mkdir -p ' + csdir )
         errRun( 'mount -t cgroup -ocpuset cpuset ' + csdir )
 


### PR DESCRIPTION
Trying to fix #169

Changed mountCgroups to use the file /proc/mounts (instead of the
current case where it uses the less reliable
(http://www.mail-archive.com/lxc-devel@lists.sourceforge.net/msg00455.html)
/etc/mtab thorugh the mount program
