### PR TITLE
Extensibility Improvements

### DIFF
--- a/util/install.sh
+++ b/util/install.sh
@@ -185,7 +185,12 @@ function of13 {
         unzip libpcre3-dev flex bison libboost-dev
 
     if [ ! -d "ofsoftswitch13" ]; then
-         git clone https://github.com/CPqD/ofsoftswitch13.git
+        git clone https://github.com/CPqD/ofsoftswitch13.git
+        if [[ -n "$OF13_SWITCH_REV" ]]; then
+            cd ofsoftswitch13
+            git checkout ${OF13_SWITCH_REV}
+            cd ..
+        fi
     fi
 
     # Install netbee


### PR DESCRIPTION
Allows the user running the installer to specify an explicit version of either the OF 1.3 soft switch and/or the OF dissector.  Both of these have had commits to head breaking functionality, so enabling a specific version to be selected is critical.
