### PR TITLE
(Pending) Fixes to issues related to unreachable hosts with iperf  

### DIFF
--- a/mininet/net.py
+++ b/mininet/net.py
@@ -608,9 +608,36 @@ class Mininet( object ):
            hosts: list of hosts; if None, uses opposite hosts
            l4Type: string, one of [ TCP, UDP ]
            returns: results two-element array of server and client speeds"""
+        
+        """
+        Currently when the server side iperf service not reachable by the client, 
+        the mininet console either hangs forever (not responsive to to any keys 
+        Or continuously prints the message "waiting for iperf to startup"
+        Actually there are two issues :
+            1. when iperf session end point was created in mininet , if connectivity exists
+            client will know in matter of secs . Per
+            per current login client waits forever without yielding. default telnet wait 
+            time of 60 secs is good enough. Therefore while loop is not necessary. If 
+            statement is good enough.
+            2. Since client to server connectivity can be verified within few secs, telnet with 60 sec 
+            timeout is overkill. You get console full of msgs or console doesnt yield or 
+            hangs till telnet timeout. We can accomplish the same verification . It is common 
+            practice to use netcat(nc) to accomplish the same.
+        Fix has been verified with iperf between hosts, between unreachable hosts, switches.
+        """
+
+           
+        """ commented 
         if not quietRun( 'which telnet' ):
             error( 'Cannot find telnet in $PATH - required for iperf test' )
             return
+
+        """
+
+        if not quietRun( 'which nc' ):
+            error( 'Cannot find nc in $PATH - required for iperf test' )
+            return
+
         if not hosts:
             hosts = [ self.hosts[ 0 ], self.hosts[ -1 ] ]
         else:
@@ -631,10 +658,29 @@ class Mininet( object ):
         while server.lastPid is None:
             servout += server.monitor()
         if l4Type == 'TCP':
+
+            """
+            While loop is replaced by if block
+
             while 'Connected' not in client.cmd(
                     'sh -c "echo A | telnet -e A %s 5001"' % server.IP()):
                 output('waiting for iperf to start up...')
                 sleep(.5)
+
+            """
+        if l4Type == 'TCP':
+            sleep(0.5)
+            ### Changed to handle a. hang issue when one of the hosts not reachable
+            ### b. continuous waiting loop c. reduced waiting verification using Net cat vs telnet
+            if ( 'succeeded' not in client.cmd(
+                    'nc -w 3 -v -z  %s 5001' % server.IP())) :
+                output('waiting for iperf to start up...\n')
+                ## since session has failed, cleanup server end point and 
+                server.sendInt()
+                servout += server.waitOutput()
+                error("\niperf Error: Unable to reach the server %s on port 5001. iperf failed \n\n" %server.IP() )
+                return 
+
         cliout = client.cmd( iperfArgs + '-t 5 -c ' + server.IP() + ' ' +
                              bwArgs )
         debug( 'Client output: %s\n' % cliout )


### PR DESCRIPTION
when user on mininet console issues a command : iperf h1 h2; 
            and when one of the host is not reachable from the other , console will hang or continue to print " waiting for server to be ready message".  Fix involves 2 changes. Replace "while loop" with "if block" of code. Replace telnet mechanism with netcat mechanism. (which reduces the unnecessary 1 minute wait of telnet to few secs).

Fix has been tested under following conditions :
1. mininet topos : minimal, tree(depth=3,fanout=4 with 64 hosts), linear(16 hosts)
2. iperf between different reachable and unreachable hosts
3. made sure pingall and pingpair is not broken.
## How to reproduce the issue in the current image

sudo mn --topo minimal

mininet> iperf h1 h2
**\* Iperf: testing TCP bandwidth between h1 and h2
**\* Results: ['760 Mbits/sec', '761 Mbits/sec']
mininet> iperf h2 h1
**\* Iperf: testing TCP bandwidth between h2 and h1
**\* Results: ['735 Mbits/sec', '736 Mbits/sec']
mininet> iperf s1 h1
**\* Iperf: testing TCP bandwidth between s1 and h1  ###console kind of hangs
^C
Interrupt
^C
Interrupt
^C
Interrupt
^C
Interrupt
^C
Interrupt
^C
Interrupt
^C
Interrupt
waiting for iperf to start up...waiting for iperf to start up...

waiting for iperf to start up...waiting for iperf to start up...waiting for iperf to start up..
