### PR TITLE
mnexec: getopt bugfix

### DIFF
--- a/mnexec.c
+++ b/mnexec.c
@@ -92,7 +92,7 @@ int cgroup(char *gname)
 
 int main(int argc, char *argv[])
 {
-    char c;
+    int c;
     int fd;
     char path[PATH_MAX];
     int nsid;


### PR DESCRIPTION
getopt returns an 'int', so use change datatype of 'c' to match it.
Otherwise, 'c' may hold a value of 255 (0xff), and fail the comparison
with -1 (0xffffffff): while ((c = getopt(...)) != -1)

This bug was uncovered on Ubuntu 13.04 running on ARM, using
arm-linux-gnueabihf-gcc4.7.
