### PR TITLE
kill entire process group in Node.terminate

### DIFF
--- a/mininet/node.py
+++ b/mininet/node.py
@@ -184,7 +184,7 @@ class Node( object ):
     def terminate( self ):
         "Send kill signal to Node and clean up after it."
         if self.shell:
-            os.kill( self.pid, signal.SIGKILL )
+            os.killpg( self.pid, signal.SIGKILL )
         self.cleanup()
 
     def stop( self ):


### PR DESCRIPTION
mnexec already puts the shell into its own process group. Killing the entire
process group cleans up after any background processes the user left running.

I ran into this issue when running tcpdump in the background on a few nodes. After quitting mininet the tcpdump processes were reparented to init and kept running.
