### PR TITLE
adjust regex for finding mininet's links during cleanup

### DIFF
--- a/mininet/clean.py
+++ b/mininet/clean.py
@@ -59,7 +59,7 @@ def cleanup():
             sh( 'ovs-vsctl del-br ' + dp )
 
     info( "*** Removing all links of the pattern foo-ethX\n" )
-    links = sh( r"ip link show | egrep -o '(\w+-eth\w+)'" ).split( '\n' )
+    links = sh( r"ip link show | egrep -o '([-_[:alnum:]]+-eth[[:digit:]]+)'" ).split( '\n' )
     for link in links:
         if link != '':
             sh( "ip link del " + link )


### PR DESCRIPTION
link names of the form "a-b-ethN" were previously interpreted
as "b-ethN". this change accepts link names with a dash, and
requires N to only contain digits.

in egrep, \w is a synonym for [_[:alnum:]]

thanks!
Andrew
