### PR TITLE
don't crash when link is TCLink but without options

### DIFF
--- a/mininet/node.py
+++ b/mininet/node.py
@@ -847,10 +847,13 @@ class UserSwitch( Switch ):
             minspeed = ifspeed * 0.001
 
             res = intf.config( **intf.params )
-            parent = res['parent']
+
+            if res is None: # link may not have TC parameters
+                return
 
             # Re-add qdisc, root, and default classes user switch created, but
             # with new parent, as setup by Mininet's TCIntf
+            parent = res['parent']
             intf.tc( "%s qdisc add dev %s " + parent +
                      " handle 1: htb default 0xfffe" )
             intf.tc( "%s class add dev %s classid 1:0xffff parent 1: htb rate "


### PR DESCRIPTION
caused by optimized return of None in link.py (line 275) in TCIntf.config()

thank you!
Andrew
