### PR TITLE
print error messages when making interfaces

### DIFF
--- a/mininet/util.py
+++ b/mininet/util.py
@@ -155,7 +155,12 @@ def makeIntfPair( intf1, intf2 ):
     quietRun( 'ip link del ' + intf2 )
     # Create new pair
     cmd = 'ip link add name ' + intf1 + ' type veth peer name ' + intf2
-    return quietRun( cmd )
+    cmdOutput = quietRun( cmd )
+    if cmdOutput == '':
+        return True
+    else:
+        error( "Error creating interface pair: %s " % cmdOutput )
+        return False
 
 def retry( retries, delaySecs, fn, *args, **keywords ):
     """Try something several times before giving up.


### PR DESCRIPTION
without this, there is no indication in Mininet that creating an
interface has failed. for example, this may happen when the interface
name is too long (longer than IFNAMSIZ, which is 16 chars).

thank you!
Andrew
