### PR TITLE
Add LINC-Switch to Mininet

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,9 @@ several new features, including:
 * support for installing the OpenFlow 1.3 versions of the reference
   user switch and NOX from CPqD
 * The ability to import modules from `mininet.examples`
+* Support for installing the
+  [LINC-Switch](https://github.com/FlowForwarding/LINC-Switch)
+  that supports OpenFlow 1.3.2
 
 We have provided several new examples (which can easily be
 imported to provide useful functionality) including:

--- a/bin/mn
+++ b/bin/mn
@@ -26,7 +26,7 @@ from mininet.log import lg, LEVELS, info, debug, error
 from mininet.net import Mininet, MininetWithControlNet, VERSION
 from mininet.node import ( Host, CPULimitedHost, Controller, OVSController,
                            NOX, RemoteController, UserSwitch, OVSKernelSwitch,
-                           OVSLegacyKernelSwitch, IVSSwitch )
+                           OVSLegacyKernelSwitch, IVSSwitch, LincSwitch )
 from mininet.link import Link, TCLink
 from mininet.topo import SingleSwitchTopo, LinearTopo, SingleSwitchReversedTopo
 from mininet.topolib import TreeTopo
@@ -46,7 +46,8 @@ SWITCHDEF = 'ovsk'
 SWITCHES = { 'user': UserSwitch,
              'ovsk': OVSKernelSwitch,
              'ovsl': OVSLegacyKernelSwitch,
-             'ivs': IVSSwitch }
+             'ivs': IVSSwitch,
+             'linc' : LincSwitch}
 
 HOSTDEF = 'proc'
 HOSTS = { 'proc': Host,

--- a/mininet/clean.py
+++ b/mininet/clean.py
@@ -26,7 +26,7 @@ def cleanup():
        do fast stuff before slow dp and link removal!"""
 
     info("*** Removing excess controllers/ofprotocols/ofdatapaths/pings/noxes"
-         "\n")
+         "/LINC-Switch\n")
     zombies = 'controller ofprotocol ofdatapath ping nox_core lt-nox_core '
     zombies += 'ovs-openflowd ovs-controller udpbwtest mnexec ivs'
     # Note: real zombie processes can't actually be killed, since they
@@ -64,4 +64,14 @@ def cleanup():
         if link != '':
             sh( "ip link del " + link )
 
+    lincCleanup()
+
     info( "*** Cleanup complete.\n" )
+
+def lincCleanup():
+    "Clean up stuff related with LINC-Switch"
+
+    getPidsCmd = "pgrep -f linc"
+    sh('kill `' + getPidsCmd + '` 2> /dev/null')
+    sh('kill -9`' + getPidsCmd + '` 2> /dev/null')
+    sh('linc_rel -D')

--- a/mininet/node.py
+++ b/mininet/node.py
@@ -21,6 +21,9 @@ Switch: superclass for switch nodes.
 UserSwitch: a switch using the user-space switch from the OpenFlow
     reference implementation.
 
+LincSwitch: an OpenFlow user-space switch implemented entirely in Erlang
+    currently supporting OF protocol v. 1.3.1.
+
 KernelSwitch: a switch using the kernel switch from the OpenFlow reference
     implementation.
 
@@ -889,6 +892,98 @@ class UserSwitch( Switch ):
         self.cmd( 'kill %ofdatapath' )
         self.cmd( 'kill %ofprotocol' )
         self.deleteIntfs()
+
+
+class LincSwitch(Switch):
+    "User-space LINC-Switch implemented in Erlang."
+
+    configGenCmd = "linc_config_gen {swName} {configArgs}"
+    startCmd = "linc {swName} start"
+    stopCmd = "linc {swName} stop"
+    relCreateCmd = "linc_rel -c {swName}"
+    relDeleteCmd = "linc_rel -d {swName}"
+    listenAddress = "127.0.0.1"
+
+    def _init_(self, name, **kwargs):
+        Switch._init_(self, name, **kwargs)
+
+    def start(self, controllers):
+        self.setupLincSwitch(controllers)
+        self.cmd('linc ' + self.name + ' start')
+
+    def stop(self):
+        for intf in self.lincIntfs + self.bridges:
+            self.deletInterface(intf)
+        self.cmd(self.stopCmd.format(swName = self.name))
+        self.cmd(self.relDeleteCmd.format(swName = self.name))
+        # Will stop the epmd daemon only if there are no nodes registered.
+        # So this command takes effect only if the last switch instance is being
+        # stopped.
+        self.cmd('epmd -kill')
+
+    def dpctl(self, *args):
+        if not self.listenPort:
+            return "can't run dpctl without passive listening port"
+        return self.cmd('dpctl tcp:{0}:{1} '.format(
+          self.listenAddress, self.listenPort) + ' '.join(args))
+
+    @classmethod
+    def setup(cls):
+        pathCheck('linc', 'linc_config_gen', 'linc_rel',
+                  moduleName='the user-space OpenFlow LINC-Switch'
+                  + ' (https://github.com/FlowForwarding/LINC-Switch)')
+
+    def setupLincSwitch(self, controllers):
+        hostsIntfs = [str( i ) for i in self.intfList() if not i.IP()]
+        self.lincIntfs = self.setupInterfacesForLinc(hostsIntfs)
+        self.bridges = self.setupBridges(zip(hostsIntfs, self.lincIntfs))
+        self.cmd(self.relCreateCmd.format(swName = self.name))
+        self.generateConfig(self.lincIntfs, controllers)
+
+    def generateConfig(self, interfaces, controllers):
+        configArgs =  self.formConfigGenLogicalSwitchIdArg(0) \
+          + " " + " ".join(interfaces) \
+          + " " + self.formConfigGenControllersArg(controllers) \
+          + " " + self.formConfigGenControllersListenerArg()
+        self.cmd(self.configGenCmd.format(swName = self.name,
+                                            configArgs = configArgs))
+
+    def formConfigGenLogicalSwitchIdArg(self, logicalSwitchId):
+        return "-s " + str(logicalSwitchId)
+
+    def formConfigGenControllersArg(self, controllers):
+        return "-c " +  " ".join(['tcp:{0}:{1}'.format(c.IP(), c.port)
+                                  for c in controllers])
+
+    def formConfigGenControllersListenerArg(self):
+        return "-l " + "127.0.0.1:{0}".format(self.listenPort)
+
+    def setupInterfacesForLinc(self, hostsIntfs):
+        lincIntfs = [ "tap-" + intf for intf in hostsIntfs ]
+        for intf in lincIntfs:
+            self.cmd('tunctl -t {0}'.format(intf))
+            self.bringInterfaceUp(intf)
+        return lincIntfs
+
+    def setupBridges(self, bridgesIntfs):
+        bridges = []
+        for idx, intfsPair in enumerate(bridgesIntfs):
+            bridgeName = 'br-{0}-{1}'.format(self.name, idx)
+            bridges.append(bridgeName)
+            self.cmd('brctl addbr {0}'.format(bridgeName))
+            for intf in intfsPair:
+                self.addInterfaceToBridge(bridgeName, intf)
+            self.bringInterfaceUp(bridgeName)
+        return bridges
+
+    def addInterfaceToBridge(self, bridge, interface):
+        self.cmd('brctl addif {0} {1}'.format(bridge, interface))
+
+    def bringInterfaceUp(self, interface):
+        self.cmd('ip link set dev {0} up'.format(interface))
+
+    def deletInterface(self, interface):
+        self.cmd('ip link delete {0}'.format(interface))
 
 
 class OVSLegacyKernelSwitch( Switch ):

--- a/util/install.sh
+++ b/util/install.sh
@@ -103,6 +103,7 @@ IVS_TAG=v0.3
 # WS_DISSECTOR_REV=pre-ws-1.10.0 install.sh -w
 WS_DISSECTOR_REV=${WS_DISSECTOR_REV:-""}
 OF13_SWITCH_REV=${OF13_SWITCH_REV:-""}
+LINC_SWITCH_REV=${LINC_SWITCH_REV:-""}
 
 
 function kernel {
@@ -236,6 +237,68 @@ function of13 {
     make
     sudo make install
     cd $BUILD_DIR
+}
+
+function linc_switch {
+    echo "Installing LINC-Switch"
+    cd $BUILD_DIR/
+    set +o nounset
+
+    sudo apt-get update
+    $install git-core make uml-utilities bridge-utils libpcap-dev libssl-dev libncurses5-dev
+
+    ERL_RELEASE="R15B02"
+    ERL_DESTINATION="/usr/local/lib/$ERL_RELEASE"
+    install_erlang $ERL_RELEASE $ERL_DESTINATION
+    . $ERL_DESTINATION/activate
+
+    LINC_SWITCH_DIR=$BUILD_DIR/"LINC-Switch"
+
+    if [ -d $LINC_SWITCH_DIR ]; then
+        rm -rf $LINC_SWITCH_DIR
+    fi
+
+    git clone https://github.com/FlowForwarding/LINC-Switch.git
+    cd $LINC_SWITCH_DIR
+
+    if [[ -n "$LINC_SWITCH_REV" ]]; then
+        git checkout ${LINC_SWITCH_REV}
+    fi
+
+    REL_DIR=$LINC_SWITCH_DIR/rel
+    cp $REL_DIR/files/sys.config.orig $REL_DIR/files/sys.config
+    make rel
+
+    LINC_REL_COMMAND=$(echo "#!/usr/bin/env bash"\
+                            "\n$LINC_SWITCH_DIR/scripts/rel_copy.sh \$@")
+    install_command "$LINC_REL_COMMAND" $REL_DIR/linc_rel.sh linc_rel
+
+    LINC_RUN_USAGE="Usage: \$0 SWITCH_NAME {start|stop|restart|reboot|ping|console|console_clean|attach}"
+    LINC_RUN_SWITCH_DOWN="Switch \$REL_SUFFIX is not running."
+    LINC_RUN_COMMAND=$(echo "#!/usr/bin/env bash"\
+                            "\ntest \$# -lt 2 && echo \"$LINC_RUN_USAGE\" && exit 1"\
+                            "\nREL_SUFFIX=\$1"\
+                            "\ntest ! -d $REL_DIR/linc_\$REL_SUFFIX"\
+                            "&& echo \"$LINC_RUN_SWITCH_DOWN\" && exit 1"\
+                            "\n$REL_DIR/linc_\$REL_SUFFIX/bin/linc \${@:2}")
+    install_command "$LINC_RUN_COMMAND" $REL_DIR/linc_runner.sh linc
+
+    CONFIG_GEN_COMMAND=$(echo "#!/usr/bin/env bash"\
+                              "\n. $ERL_DESTINATION/activate"\
+                              "\nREL_SUFFIX=\$1"\
+                              "\n$LINC_SWITCH_DIR/scripts/config_gen \${@:2} "\
+                              "-o $REL_DIR/linc_\$REL_SUFFIX/releases/*/sys.config")
+    install_command "$CONFIG_GEN_COMMAND" $REL_DIR/linc_config_gen.sh \
+        linc_config_gen
+
+    LINC_CONTROLLER_COMMAND=$(echo "#!/usr/bin/env bash"\
+                                   "\n. $ERL_DESTINATION/activate"\
+                                   "\ncd $LINC_SWITCH_DIR/scripts/"\
+                                   "\n./of_controller_v4.sh \$@")
+    install_command "$LINC_CONTROLLER_COMMAND" $REL_DIR/linc_controller.sh linc_controller
+
+    set -o nounset
+    cd $BUILD_DIR/
 }
 
 function wireshark_version_check {
@@ -705,6 +768,44 @@ function vm_clean {
 
 }
 
+function install_erlang {
+    ERL_RELEASE=$1
+    ERL_DESTINATION=$2
+    ERL_RELEASE_NAME=$ERL_RELEASE
+
+    if [ ! `which kerl` ]; then
+        KERL_DESTINATION="/usr/local/bin/kerl"
+        curl -o $KERL_DESTINATION -O https://raw.github.com/spawngrid/kerl/master/kerl
+        chmod a+x $KERL_DESTINATION
+    fi
+
+    if [ ! `kerl list builds | grep $ERL_RELEASE` ]; then
+        kerl build $ERL_RELEASE $ERL_RELEASE_NAME
+        kerl install $ERL_RELEASE_NAME $ERL_DESTINATION
+    fi
+}
+
+# Install a command to /usr/bin directory for easy access.
+# The function takes three argument in the following order:
+# 1. Command - the command to be executed
+# 2. CommandPath - the file in which the command should be placed
+# 3. CommandName - the name of the command under which it will be available
+#    in the /usr/bin directory
+function install_command {
+    COMMAND=$1
+    COMMAND_PATH=$2
+    COMMAND_NAME=$3
+
+    echo -e $COMMAND > $COMMAND_PATH
+    chmod u+x $COMMAND_PATH
+
+    if [ `which $COMMAND_NAME` ]; then
+        sudo update-alternatives --remove-all $COMMAND_NAME > /dev/null 2>&1
+    fi
+    sudo update-alternatives --install /usr/bin/$COMMAND_NAME $COMMAND_NAME \
+        $COMMAND_PATH 0 > /dev/null  2>&1
+}
+
 function usage {
     printf '\nUsage: %s [-abcdfhikmnprtvwx03]\n\n' $(basename $0) >&2
 
@@ -735,6 +836,7 @@ function usage {
     printf -- ' -x: install NO(X) Classic OpenFlow controller\n' >&2
     printf -- ' -0: (default) -0[fx] installs OpenFlow 1.0 versions\n' >&2
     printf -- ' -3: -3[fx] installs OpenFlow 1.3 versions\n' >&2
+    printf -- ' -L: install LINC-Switch\n' >&2
     exit 2
 }
 
@@ -744,7 +846,7 @@ if [ $# -eq 0 ]
 then
     all
 else
-    while getopts 'abcdefhikmnprs:tvwx03' OPTION
+    while getopts 'abcdefhikmnprs:tvwx03L' OPTION
     do
       case $OPTION in
       a)    all;;
@@ -777,6 +879,7 @@ else
             esac;;
       0)    OF_VERSION=1.0;;
       3)    OF_VERSION=1.3;;
+      L)    linc_switch;;
       ?)    usage;;
       esac
     done


### PR DESCRIPTION
LINC-Switch is an OpenFlow software switch written in Erlang. Currently
the latest supported version of OpenFlow is 1.3.2. More information can be
found here: https://github.com/FlowForwarding/LINC-Switch. Tutorial
explaining how to run LINC-Switch on Mininet can be found here:
https://github.com/FlowForwarding/LINC-Switch/blob/master/docs/mininet_integration.md.
FlowForwarding also provides easy to setup virtual environment
that is equipped with all required software to run Mininet with LINC:
https://github.com/FlowForwarding/LINC-Environment.
