### PR TITLE
userspace switch can be reached on unix port by dpctl

### DIFF
--- a/mininet/node.py
+++ b/mininet/node.py
@@ -827,10 +827,13 @@ class UserSwitch( Switch ):
 
     def dpctl( self, *args ):
         "Run dpctl command"
+        listenAddr = None
         if not self.listenPort:
-            return "can't run dpctl without passive listening port"
+            listenAddr = 'unix:/tmp/' + self.name
+        else:
+            listenAddr = 'tcp:127.0.0.1:%i' % self.listenPort
         return self.cmd( 'dpctl ' + ' '.join( args ) +
-                         ' tcp:127.0.0.1:%i' % self.listenPort )
+                         ' ' + listenAddr )
 
     def connected( self ):
         "Is the switch connected to a controller?"


### PR DESCRIPTION
when using the userspace switch without a passive TCP listening port, we can reach it on the local Unix socket to run dpctl commands.

thanks!
Andrew
