### PR TITLE
OVSSwitch: use the OVSDB protocol directly for batch operations

### DIFF
--- a/mininet/ovsdb.py
+++ b/mininet/ovsdb.py
@@ -1,0 +1,196 @@
+import os
+import sys
+import Queue
+import socket
+import json
+from select import select
+
+OVSDB_IP = '127.0.0.1'
+OVSDB_PORT = 6632
+DEFAULT_DB = 'Open_vSwitch'
+BUFFER_SIZE = 4096
+
+pid = None
+last_id = 0
+
+def generate_id():
+    global pid
+    global last_id
+    if pid is None:
+        pid = os.getpid()
+    last_id += 1
+    return "%d-%d" % (pid, last_id)
+
+# ----------------------------------------------------------------------
+
+
+# TODO: Could start by getting the DB name and using that for ongoing requests
+# TODO: How to keep an eye out for montor, update, echo messages?
+def gather_reply(socket):
+    #print "Waiting for reply"
+    result = ""
+    while True:
+        reply = socket.recv(BUFFER_SIZE)
+        result += reply
+        # we got the whole thing if we received all the fields
+        if "error" in result and "id" in result and "result" in result:
+            try:
+                return json.loads(result)
+            except ValueError:
+                pass
+
+def listen_for_messages(sock, message_queues):
+    # To send something, add a message to queue and append sock to outputs
+    inputs = [sock, sys.stdin]
+    outputs = []
+    while sock:
+        readable, writable, exceptional = select(inputs, outputs, [])
+        for s in readable:
+            if s is sock:
+                data = sock.recv(4096)
+                # should test if its echo, if so, reply
+                # message_type = get_msg_type(data)
+                # if message_type is "echo":
+                #   send_echo(message_
+                message_queues[sock].put(data)
+                outputs.append(sock)
+                print "recv:" + data
+            elif s is sys.stdin:
+                print sys.stdin.readline()
+                sock.close()
+                return
+            else:
+                print "error"
+        for w in writable:
+            if w is sock:
+                sock.send(message_queues[sock].get_nowait())
+                outputs.remove(sock)
+            else:
+                print "error"
+
+def list_dbs():
+    list_dbs_query =  {"method":"list_dbs", "params":[], "id": 0}
+    return json.dumps(list_dbs_query)
+
+def get_schema(socket, db = DEFAULT_DB, current_id = 0):
+    list_schema = {"method": "get_schema", "params":[db_name], "id": current_id}
+    socket.send(json.dumps(list_schema))
+    result = gather_reply(socket)
+    return result
+
+def get_schema_version(socket, db = DEFAULT_DB):
+    db_schema = get_schema(socket, db)
+    return db_schema['version']
+
+def list_tables(server, db):
+    # keys that are under 'tables'
+    db_schema = get_schema(socket, db)
+    # return db_schema['tables'].keys
+    return json.loads()
+
+def list_columns(server, db):
+    return
+
+def transact(s, db, operations):
+    # Variants of this will add stuff
+    request = { "method": "transact",
+                "params": [db] + operations,
+                "id": generate_id(),
+              }
+
+    s.send(json.dumps(request))
+    response = gather_reply(s)
+    
+    #assumtion: no overlapping calls
+    assert( request['id'] == response['id'] )
+    results = response['result']
+    if len(operations) == len(results):
+        for i, val in enumerate(zip(operations, results)):
+            if 'error' in val[1]:
+                raise RuntimeError('Op failed (%d, %s): %s' %
+                                   (i, val[0], val[1]))
+    else:
+        raise RuntimeError('transact failed: %s' % results[-1])
+
+    return results
+
+def monitor(columns, monitor_id = None, db = DEFAULT_DB):
+    msg = {"method":"monitor", "params":[db, monitor_id, columns], "id":0}
+    return json.dumps(msg)
+
+def monitor_cancel():
+    return
+
+def locking():
+    return
+
+def echo():
+    echo_msg = {"method":"echo","id":"echo","params":[]}
+    return json.dumps(echo_msg)
+
+def dump(server, db):
+    return
+
+def list_bridges(db = DEFAULT_DB):
+    # What if we replaced with a more specific query
+    # columns = {"Bridge":{"name"}}
+    columns = {"Port":{"columns":["fake_bridge","interfaces","name","tag"]},"Controller":{"columns":[]},"Interface":{"columns":["name"]},"Open_vSwitch":{"columns":["bridges","cur_cfg"]},"Bridge":{"columns":["controller","fail_mode","name","ports"]}}
+    # TODO: cancel the monitor after we're done?
+    return monitor(columns, db)
+
+daemon_uuid = None
+def get_daemon_uuid(socket, db = DEFAULT_DB):
+    "Get the uuid from table Open_vSwitch"
+    global daemon_uuid
+    if daemon_uuid:
+        return daemon_uuid
+    op = {"op": "select",
+          "table": "Open_vSwitch",
+          "where": [],
+          "columns": ["_uuid"],
+          }
+    reply = transact(socket, db, [op])
+    try:
+        if (len(reply[0]['rows']) != 1):
+            e = 'There must be exactly one record in the Open_vSwitch table.'
+            raise RuntimeError(e) 
+        daemon_uuid = reply[0]['rows'][0]['_uuid'][1]
+    except (KeyError, TypeError):
+        raise RuntimeError("Database schema changed")
+    return daemon_uuid
+
+if __name__ == '__main__':
+    if False:
+        s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        s.connect((OVSDB_IP, OVSDB_PORT))
+    else:
+        s = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        s.connect('/var/run/openvswitch/db.sock')
+
+    current_id = 0
+
+    s.send(list_dbs())
+    db_list = gather_reply(s)
+    db_name = db_list['result'][0]
+    print "db_name", db_list
+
+    print "list bridges:"
+    s.send(list_bridges())
+    bridge_list = gather_reply(s)
+    print bridge_list
+    bridges = bridge_list['result']['Bridge']
+    print "\nbridges\n"
+    print bridges.values()
+    for bridge in bridges.values():
+        print "---"
+        print bridge['new']['name']
+    #db_schema = get_schema(s, db_name)
+    #print db_schema
+
+    #columns = {"Bridge":{"columns":["name"]}}
+    #print monitor(s, columns, 1)
+
+    # TODO: Put this in a thread and use Queues to send/recv data from the thread
+    message_queues = {}
+    message_queues[s] = Queue.Queue()
+    listen_for_messages(s, message_queues)


### PR DESCRIPTION
net: group batch operations based on switch type
ovsdb.py: new file

---

I send this pull request as an alternative to #286.  Similarly to that, this pull request attempts to improve mininet's performance during startup and shutdown.

I measured 'mn --test=none --topo=linear,k=K' with different K values:

```
   k  orig  ovsbatch  ovsdb_batch
  25    51    37       34
  50   113    87       74
 100   273   189      171
 150   503   318      285
 200   787   458      395
 300  2261   883      703
```

measuring just the 'starting switches' phase:

```
   k  orig  ovsbatch  ovsdb_batch
  25    16     7        4
  50    35    16        9
 100   101    35       17
 150   212    66       25
 200   353   102       30
 300  1352   258       45
```

measuring just the 'stopping switches' phase:

```
   k  orig  ovsbatch  ovsdb_batch
  25     9     5        5
  50    21    17       12
 100    54    36       30
 150   104    63       50
 200   167    71       67
 300   439   109      148
```

This this version (ovsdb_batch) is slower than ovsbatch (#286) because it calls deleteIntfs in the end (which might be unnecessary)

So performancewise this version is quite good, but currently it has some drawbacks:
- The license of the ovsdb library is unknown.  (But I can extract the parts that the pull request really needs.  These parts were written mostly by me.)
- It probably doesn't follow the coding standards of mininet.
- It sends one large ovsdb transaction.  Probably, it is better to configure the network in smaller chunks (say, 100 nodes per transaction.)

However, I think, at least the implementation of starting/stoping switches in a batch is more robust than that of #286.

My original goal with this work was to familiarize with the ovsdb protocol, but, as usual, if there's an interest in this pull request, I'd be happy to incorporate feedback.
