### PR TITLE
IVSSwitch: wait for ivs to terminate before tearing down node

### DIFF
--- a/mininet/node.py
+++ b/mininet/node.py
@@ -1124,6 +1124,7 @@ class IVSSwitch(Switch):
     def stop( self ):
         "Terminate IVS switch."
         self.cmd( 'kill %ivs' )
+        self.cmd( 'wait' )
         self.deleteIntfs()
 
     def attach( self, intf ):


### PR DESCRIPTION
This was a problem when running IVS in a container. IVS would begin the process
of closing controller connections on receiving SIGTERM, but often mininet would
have continued on and removed the control network interface from the container
before it could send the FIN. The controller wouldn't know the connection had
been closed until it timed out much later.

This may be a problem with other switches as well.
