### PR TITLE
Use multiprocessing to parallelize switch startup

### DIFF
--- a/mininet/net.py
+++ b/mininet/net.py
@@ -92,6 +92,7 @@ import select
 import signal
 from time import sleep
 from itertools import chain
+from multiprocessing import Process
 
 from mininet.cli import CLI
 from mininet.log import info, error, debug, output
@@ -397,10 +398,15 @@ class Mininet( object ):
         for controller in self.controllers:
             controller.start()
         info( '*** Starting %s switches\n' % len( self.switches ) )
+        processes = []
         for switch in self.switches:
             info( switch.name + ' ')
-            switch.start( self.controllers )
+            process = Process(target=switch.start, args=(self.controllers,))
+            process.start()
+            processes.append(process)
         info( '\n' )
+        for process in processes:
+            process.join()
 
     def stop( self ):
         "Stop the controller(s), switches and hosts"


### PR DESCRIPTION
To get the ball rolling for improving link creation and switch startup times in Mininet, this simple patches parallelizes the switch creation by using the `multiprocessing` module. I have tested this patch with:

```
# mn --version
2.1.0+
```

```
# ovs-ofctl --version
ovs-ofctl (Open vSwitch) 1.4.6
Compiled Jan 10 2014 01:45:55
OpenFlow versions 0x1:0x1
```

and using the `POX` controller. As a comparison: it takes 154 seconds to start 100 `OVS` switches without this patch but it takes 65 seconds with the patch applied (on a really powerful machine). CPU usage with the patch is ~98-99% on all cores as the switches are being created.

I am sure we can do better, but I am submitting this request so that we can discuss it further. Also, for whatever reason, I **cannot** get this to work with `OVS 2.1.0`:

```
# ovs-ofctl --version
ovs-ofctl (Open vSwitch) 2.1.0
Compiled Apr  1 2014 02:06:32
OpenFlow versions 0x1:0x4
```

Some switches are created, but there are socket errors for others. Suggestions on fixing this for `OVS 2.x` are also welcome.
