### PR TITLE
Change default controller from ovsc to ref for mn

### DIFF
--- a/bin/mn
+++ b/bin/mn
@@ -53,7 +53,7 @@ HOSTS = { 'proc': Host,
           'rt': custom( CPULimitedHost, sched='rt' ),
           'cfs': custom( CPULimitedHost, sched='cfs' ) }
 
-CONTROLLERDEF = 'ovsc'
+CONTROLLERDEF = 'ref'
 CONTROLLERS = { 'ref': Controller,
                 'ovsc': OVSController,
                 'nox': NOX,


### PR DESCRIPTION
Change the default controller used for 'mn' fro ovsc to ref.
1. Now the default controller between using mn and Python script are the same.
2. ovs-controller is gone in its current form a of OVS 2.1.0.
