### PR TITLE
OVS switch connect to controllers using protocols other than TCP like SSL.

### DIFF
--- a/mininet/node.py
+++ b/mininet/node.py
@@ -1048,7 +1048,7 @@ class OVSSwitch( Switch ):
         # Interfaces and controllers
         intfs = ' '.join( '-- add-port %s %s ' % ( self, intf )
                          for intf in self.intfList() if not intf.IP() )
-        clist = ' '.join( 'tcp:%s:%d' % ( c.IP(), c.port )
+        clist = ' '.join( '%s:%s:%d' % ( c.protocol, c.IP(), c.port )
                          for c in controllers )
         if self.listenPort:
             clist += ' ptcp:%s' % self.listenPort
@@ -1154,12 +1154,13 @@ class Controller( Node ):
 
     def __init__( self, name, inNamespace=False, command='controller',
                   cargs='-v ptcp:%d', cdir=None, ip="127.0.0.1",
-                  port=6633, **params ):
+                  port=6633, protocol='tcp', **params ):
         self.command = command
         self.cargs = cargs
         self.cdir = cdir
         self.ip = ip
         self.port = port
+        self.protocol = protocol
         Node.__init__( self, name, inNamespace=inNamespace,
                        ip=ip, **params  )
         self.cmd( 'ifconfig lo up' )  # Shouldn't be necessary


### PR DESCRIPTION
Add ability for for OVS switch start connect to controllers using protocols other than TCP.

```
net.addController( 'c0', protocol='ssl' )
```

This now allows OVS to connect to a controller using SSL.  The default of protocol is 'tcp'
as it currently is.  When adding a controller, you specify the protocol and then that value is used during switch.start().  Example and test python script used shown below.

```
#!/usr/bin/python
from mininet.net import Mininet
from mininet.node import Controller, RemoteController, OVSController
from mininet.cli import CLI
from mininet.log import setLogLevel, info

def emptyNet():
    net = Mininet( controller=OVSController )
    net.addController( 'c0',
        cargs='-v pssl:%d -p /etc/openvswitch/ctl-privkey.pem \
               -c /etc/openvswitch/ctl-cert.pem \
               -C /var/lib/openvswitch/pki/switchca/cacert.pem',
        protocol='ssl' )
    h1 = net.addHost( 'h1' )
    h2 = net.addHost( 'h2' )
    s1 = net.addSwitch( 's1' )
    net.addLink( h1, s1 )
    net.addLink( h2, s1 )

    net.start()
    net.pingAll()
    CLI( net )
    net.stop()

if __name__ == '__main__':
    setLogLevel( 'info' )
    emptyNet()
```

  Shows OVS listening on SSL.

```
root@mininet21:~/SVN/mininet# sudo ovs-vsctl show
ec21cc9e-4dc3-44d1-8c18-f23409d4615c
    Bridge "s1"
        Controller "ssl:127.0.0.1:6633"
            is_connected: true
        fail_mode: secure
        Port "s1"
            Interface "s1"
                type: internal
        Port "s1-eth2"
            Interface "s1-eth2"
        Port "s1-eth1"
            Interface "s1-eth1"
    ovs_version: "1.4.6"
```

Output of script.

```
mininet@mininet21:~$ sudo ./ssl2.py
*** Configuring hosts
h1 h2
*** Starting controller
*** Starting 1 switches
s1
*** Ping: testing ping reachability
h1 -> h2
h2 -> h1
*** Results: 0% dropped (2/2 received)
*** Starting CLI:
```

  All this assumes that the user setup the SSL keys as described in the FAQ/wiki.
