### PR TITLE
fixed netParse bug that caused mininet crash when no ip prefix was specified

### DIFF
--- a/mininet/util.py
+++ b/mininet/util.py
@@ -281,6 +281,8 @@ def ipAdd( i, prefixLen=8, ipBaseNum=0x0a000000 ):
 def ipParse( ip ):
     "Parse an IP address and return an unsigned int."
     args = [ int( arg ) for arg in ip.split( '.' ) ]
+    while ( len(args) < 4 ):
+        args.append( 0 )
     return ipNum( *args )
 
 def netParse( ipstr ):
@@ -290,6 +292,10 @@ def netParse( ipstr ):
     if '/' in ipstr:
         ip, pf = ipstr.split( '/' )
         prefixLen = int( pf )
+    #if no prefix is specified, set the prefix to 24
+    else:
+        ip = ipstr
+        prefixLen = 24
     return ipParse( ip ), prefixLen
 
 def checkInt( s ):


### PR DESCRIPTION
assumes prefix is 24 if none is specified.
Also allows you to input different values into --ipBase without crash, i.e. --ipBase=10, --ipBase=10/16, --ipBase=192.168/16

fixes #236 
fixes #272 
