### PR TITLE
Add build() method to simplify Topo() usage

### DIFF
--- a/mininet/topo.py
+++ b/mininet/topo.py
@@ -48,18 +48,25 @@ class MultiGraph( object ):
 class Topo(object):
     "Data center network representation for structured multi-trees."
 
-    def __init__(self, hopts=None, sopts=None, lopts=None):
-        """Topo object:
+    def __init__(self, *args, **params):
+        """Topo object. 
+           Optional named parameters:
            hinfo: default host options
            sopts: default switch options
-           lopts: default link options"""
+           lopts: default link options
+           calls build()"""
         self.g = MultiGraph()
         self.node_info = {}
         self.link_info = {}  # (src, dst) tuples hash to EdgeInfo objects
-        self.hopts = {} if hopts is None else hopts
-        self.sopts = {} if sopts is None else sopts
-        self.lopts = {} if lopts is None else lopts
+        self.hopts = params.pop( 'hopts', {} )
+        self.sopts = params.pop( 'sopts', {} )
+        self.lopts = params.pop( 'lopts', {} )
         self.ports = {}  # ports[src][dst] is port on src that connects to dst
+        self.build( *args, **params )
+
+    def build( self, *args, **params ):
+        "Override this method to build your topology."
+        pass
 
     def addNode(self, name, **opts):
         """Add Node to graph.


### PR DESCRIPTION
This is my idea for simplifying `Topo()` subclassing, by introducing a `build()` method which can be overridden in place of `__init__()`. This makes a simple topology look like:

``` python
class MyTopo( Topo ):
    def build( self ):
        h1, h2 = self.addHost( 'h1' ), self.addHost( 'h2' )
        s1 = self.addLink( h1, h2 )
```

Note that arguments and parameters that are passed into the constructor are also passed to `build()`.

I was contemplating saving them in the object as well, but for now I lean toward leaving that up to the topo implementor.
