### PR TITLE
adding waitConnected to linear5 test

### DIFF
--- a/mininet/test/test_nets.py
+++ b/mininet/test/test_nets.py
@@ -66,7 +66,7 @@ class testLinearCommon( object ):
 
     def testLinear5( self ):
         "Ping test on a 5-switch topology"
-        mn = Mininet( LinearTopo( k=5 ), self.switchClass, Host, Controller )
+        mn = Mininet( LinearTopo( k=5 ), self.switchClass, Host, Controller, waitConnected=True )
         dropped = mn.run( mn.ping )
         self.assertEqual( dropped, 0 )
 


### PR DESCRIPTION
this is the test that dies occasionally in the nightly builds. forgot to add this in my last pull request
