### PR TITLE
Tolerate passing controller *objects* into Mininet()

### DIFF
--- a/mininet/net.py
+++ b/mininet/net.py
@@ -246,7 +246,7 @@ class Mininet( object ):
         if not controller:
             controller = self.controller
         # Construct new controller if one is not given
-        if isinstance(name, Controller):
+        if isinstance( name, Controller ):
             controller_new = name
             # Pylint thinks controller is a str()
             # pylint: disable=E1103
@@ -357,7 +357,11 @@ class Mininet( object ):
             if type( classes ) is not list:
                 classes = [ classes ]
             for i, cls in enumerate( classes ):
-                self.addController( 'c%d' % i, cls )
+                # Allow Controller objects because nobody understands partial()
+                if isinstance( cls, Controller ):
+                    self.addController( cls )
+                else:
+                    self.addController( 'c%d' % i, cls )
 
         info( '*** Adding hosts:\n' )
         for hostName in topo.hosts():


### PR DESCRIPTION
In spite of the documentation which clearly says that `Mininet()` takes a controller _constructor_, people frequently want to pass in a controller _object_. Although explaining `partial()` might make the world a better place, for now we can just let them do this. In fact, we'll let them even pass in a list of prefabricated `Controller` objects if they so desire.

We still won't let them pass in an object which isn't a descendant of `Controller`, however.
