### PR TITLE
fallback to lxbr switch when no default controllers are available

### DIFF
--- a/bin/mn
+++ b/bin/mn
@@ -26,7 +26,7 @@ from mininet.log import lg, LEVELS, info, debug, error
 from mininet.net import Mininet, MininetWithControlNet, VERSION
 from mininet.node import ( Host, CPULimitedHost, Controller, OVSController,
                            NOX, RemoteController, getAvailableController,
-                           UserSwitch, OVSSwitch,
+                           UserSwitch, OVSBridge, OVSSwitch,
                            OVSLegacyKernelSwitch, IVSSwitch )
 from mininet.nodelib import LinuxBridge
 from mininet.link import Link, TCLink
@@ -48,6 +48,7 @@ TOPOS = { 'minimal': lambda: SingleSwitchTopo( k=2 ),
 SWITCHDEF = 'ovsk'
 SWITCHES = { 'user': UserSwitch,
              'ovs':  OVSSwitch,
+             'ovsb' : OVSBridge,
              # Keep ovsk for compatibility with 2.0
              'ovsk': OVSSwitch,
              'ovsl': OVSLegacyKernelSwitch,
@@ -204,15 +205,6 @@ class MininetRunner( object ):
 
         self.options, self.args = opts.parse_args()
 
-        if self.options.controller == "default":
-            controller_name = getAvailableController()
-            if controller_name is not None:
-                self.options.controller = controller_name
-            else:
-                # fallback to lxbr switch, which does not use OF controller
-                self.options.switch = 'lxbr'
-                self.options.controller = 'none'
-
         # We don't accept extra arguments after the options
         if self.args:
             opts.print_help()
@@ -237,6 +229,17 @@ class MininetRunner( object ):
             exit()
 
         start = time.time()
+
+        if self.options.controller == "default":
+            controller_name = getAvailableController()
+            if controller_name is not None:
+                self.options.controller = controller_name
+            else:
+                # fallback to OVS Bridge switch, which does not use OF controller
+                info('*** No default OpenFlow implementation found!\n')
+                info('    Fallback to ovsb switch implementation.\n')
+                self.options.switch = 'ovsb'
+                self.options.controller = 'none'
 
         topo = buildTopo( TOPOS, self.options.topo )
         switch = customConstructor( SWITCHES, self.options.switch )

--- a/mininet/node.py
+++ b/mininet/node.py
@@ -996,20 +996,8 @@ class OVSLegacyKernelSwitch( Switch ):
         self.deleteIntfs()
 
 
-class OVSSwitch( Switch ):
-    "Open vSwitch switch. Depends on ovs-vsctl."
-
-    def __init__( self, name, failMode='secure', datapath='kernel',
-                 inband=False, **params ):
-        """Init.
-           name: name for switch
-           failMode: controller loss behavior (secure|open)
-           datapath: userspace or kernel mode (kernel|user)
-           inband: use in-band control (False)"""
-        Switch.__init__( self, name, **params )
-        self.failMode = failMode
-        self.datapath = datapath
-        self.inband = inband
+class OVSSwitchBase( Switch ):
+    'a base class for OVS switches; does not contain OpenFlow code at all'
 
     @classmethod
     def setup( cls ):
@@ -1045,10 +1033,6 @@ class OVSSwitch( Switch ):
                   ' -- '.join( '--if-exists del-br %s' % s
                                for s in switches ) )
 
-    def dpctl( self, *args ):
-        "Run ovs-ofctl command"
-        return self.cmd( 'ovs-ofctl', args[ 0 ], self, *args[ 1: ] )
-
     @staticmethod
     def TCReapply( intf ):
         """Unfortunately OVS and Mininet are fighting
@@ -1066,6 +1050,52 @@ class OVSSwitch( Switch ):
     def detach( self, intf ):
         "Disconnect a data port"
         self.cmd( 'ovs-vsctl del-port', self, intf )
+
+
+class OVSBridge( OVSSwitchBase ):
+    "OpenVSwitch Bridge (similar to OVSSwitch, but no OpenFlow)"
+
+    def __init__( self, name, **kwargs ):
+        OVSSwitchBase.__init__( self, name, **kwargs )
+
+    def connected( self ):
+        return True
+
+    def start( self, controllers ):
+        if self.inNamespace:
+            raise Exception(
+                'OVS kernel switch does not work in a namespace' )
+        self.cmd( 'ovs-vsctl del-br', self )
+        intfs = ' '.join( '-- add-port %s %s ' % ( self, intf )
+                         for intf in self.intfList() if not intf.IP() )
+        cmd = ( 'ovs-vsctl add-br %s ' % self + intfs )
+        self.cmd( cmd )
+        for intf in self.intfList():
+            self.TCReapply( intf )
+
+    def stop( self ):
+        self.cmd( 'ovs-vsctl del-br', self )
+        self.deleteIntfs()
+
+
+class OVSSwitch( OVSSwitchBase ):
+    "Open vSwitch switch using OpenFlow controller. Depends on ovs-vsctl."
+
+    def __init__( self, name, failMode='secure', datapath='kernel',
+                 inband=False, **params ):
+        """Init.
+           name: name for switch
+           failMode: controller loss behavior (secure|open)
+           datapath: userspace or kernel mode (kernel|user)
+           inband: use in-band control (False)"""
+        OVSSwitchBase.__init__( self, name, **params )
+        self.failMode = failMode
+        self.datapath = datapath
+        self.inband = inband
+
+    def dpctl( self, *args ):
+        "Run ovs-ofctl command"
+        return self.cmd( 'ovs-ofctl', args[ 0 ], self, *args[ 1: ] )
 
     def controllerUUIDs( self ):
         "Return ovsdb UUIDs for our controllers"


### PR DESCRIPTION
Hi,
the attached patch is a preliminary, but already working solution to a problem we encountered while trying to bring Mininet to Debian (see https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=757761).
Long story short: Debian does not have any of the default OF controllers at the moment. The idea is to detect this situation and fallback to a non-OpenFlow switch implementation. I found that lxbr switch is exactly that, but in principle it could be OpenVSwitch with learning bridges (I can implement it if you find it more appropriate). This, is I think a sensible approach, because if the controllers are not available, the switches don't work and user is not even informed why.

Consider this patch to be a proof of concept. Suggestions are welcome.

Cheers,
Tomasz
