### PR TITLE
Raise exception when link incorrectly formatted

### DIFF
--- a/mininet/link.py
+++ b/mininet/link.py
@@ -279,7 +279,11 @@ class TCIntf( Intf ):
             return
 
         # Clear existing configuration
-        cmds = [ '%s qdisc del dev %s root' ]
+        tcoutput = self.tc( '%s qdisc show dev %s' )
+        if "priomap" not in tcoutput:
+            cmds = [ '%s qdisc del dev %s root' ]
+        else:
+            cmds = []
 
         # Bandwidth limits via various methods
         bwcmds, parent = self.bwCmds( bw=bw, speedup=speedup,
@@ -307,6 +311,9 @@ class TCIntf( Intf ):
         # Execute all the commands in our node
         debug("at map stage w/cmds: %s\n" % cmds)
         tcoutputs = [ self.tc(cmd) for cmd in cmds ]
+        for output in tcoutputs:
+            if output != '':
+                error( "*** Error: %s" % output )
         debug( "cmds:", cmds, '\n' )
         debug( "outputs:", tcoutputs, '\n' )
         result[ 'tcoutputs'] = tcoutputs


### PR DESCRIPTION
This is a fix for issue #95. Previously, when a link was incorrectly formatted, any errors from running the tc qdisc command were suppressed. This fix checks the return statements from running the tc qdisc command and prints out any errors. 

Additionally, to fix the previously suppressed error of "RTNETLINK answers: no such file or directory exists," after attempting to delete link configurations, the new code includes a fix to check if the qdisc exists before deleting previous configurations. 
