### PR TITLE
fix for controller shutdown

### DIFF
--- a/mininet/node.py
+++ b/mininet/node.py
@@ -1269,6 +1269,11 @@ class Controller( Node ):
                   ' 1>' + cout + ' 2>' + cout + '&' )
         self.execed = False
 
+    def stop( self ):
+        "Stop controller."
+        self.cmd( 'kill %' + self.command )
+        self.terminate()
+
     def IP( self, intf=None ):
         "Return IP address of the Controller"
         if self.intfs:


### PR DESCRIPTION
Since the pty branch( #322 ) was merged, I have had a consistent error with controller cleanup. To replicate it, start up a simple 2 host mininet topology, and wait for about 5 seconds. Shut mininet down, and try to create another mininet instance. An error should appear stating that there are still controllers running. 

I believe this is a race condition between killing the controller with controller.stop() and the shutdown of it's parent process directly afterwards, with node.terminate(). 
