### PR TITLE
OVSSwitch inNamespace check not specific enough.

### DIFF
--- a/mininet/node.py
+++ b/mininet/node.py
@@ -1088,11 +1088,15 @@ class OVSSwitch( Switch ):
                     for uuid in self.controllerUUIDs() ]
         return reduce( or_, results, False )
 
-    def start( self, controllers ):
-        "Start up a new OVS OpenFlow switch using ovs-vsctl"
-        if self.inNamespace:
+    def startPreCheck( self ):
+        "Run some prechecks before configuring OVS"
+        if self.inNamespace and datapath=='kernel':
             raise Exception(
                 'OVS kernel switch does not work in a namespace' )
+
+    def start( self, controllers ):
+        "Start up a new OVS OpenFlow switch using ovs-vsctl"
+        self.startPreCheck()
         # We should probably call config instead, but this
         # requires some rethinking...
         self.cmd( 'ifconfig lo up' )


### PR DESCRIPTION
Since the exception is about OVS kernel in namespace, it should check that the datapath chosen was kernel.

Also moving checks into a separate method to make override easier instead of copying all of
the start() method.
