### PR TITLE
fix host --rt 

### DIFF
--- a/mininet/node.py
+++ b/mininet/node.py
@@ -661,7 +661,7 @@ class CPULimitedHost( Host ):
         "Internal method: return parameters for RT bandwidth"
         pstr, qstr = 'rt_period_us', 'rt_runtime_us'
         # RT uses wall clock time for period and quota
-        quota = int( self.period_us * f * numCores() )
+        quota = int( self.period_us * f )
         return pstr, qstr, self.period_us, quota
 
     def cfsInfo( self, f):


### PR DESCRIPTION
fixes #200 
fixes #203

I believe that since RT uses wall clock time for both quota and period, we don't need to multiply by numCores as we do in cfs. 
