### PR TITLE
add sanity check for cluster edition

### DIFF
--- a/examples/cluster.py
+++ b/examples/cluster.py
@@ -129,7 +129,7 @@ class RemoteMixin( object ):
                 serverIP = self.findServerIP( server )
         self.serverIP = serverIP
         if not user:
-            user = quietRun( 'who am i' ).split()[ 0 ]
+            user = quietRun( 'echo $SUDO_USER' )
         self.user = user
         if self.user and self.server:
             self.dest = '%s@%s' % ( self.user, self.serverIP )
@@ -595,7 +595,7 @@ class MininetCluster( Mininet ):
                               for server in self.servers }
         self.user = params.pop( 'user', None )
         if self.servers and not self.user:
-            self.user = quietRun( 'who am i' ).split()[ 0 ]
+            self.user = quietRun( 'echo $SUDO_USER' )
         if params.pop( 'precheck' ):
             self.precheck()
         self.connections = {}

--- a/examples/clusterSanity.py
+++ b/examples/clusterSanity.py
@@ -1,0 +1,22 @@
+#!/usr/bin/env python
+
+'''
+A sanity check for cluster edition
+'''
+
+from mininet.examples.cluster import MininetCluster
+from mininet.log import info, setLogLevel
+from mininet.examples.clustercli import DemoCLI as CLI
+from mininet.topo import SingleSwitchTopo
+
+def clusterSanity():
+    "Sanity check for cluster mode"
+    topo = SingleSwitchTopo()
+    net = MininetCluster( topo=topo ) 
+    net.start()
+    CLI( net )
+    net.stop()
+
+if __name__  == '__main__':
+    setLogLevel( 'info' )
+    clusterSanity()

--- a/examples/test/test_clusterSanity.py
+++ b/examples/test/test_clusterSanity.py
@@ -1,0 +1,27 @@
+#!/usr/bin/env python
+
+'''
+A simple sanity check test for cluster edition
+'''
+
+import unittest
+import pexpect
+
+class clusterSanityCheck( unittest.TestCase ):
+
+    prompt = 'mininet>'
+
+    def testClusterPingAll( self ):
+        p = pexpect.spawn( 'python -m mininet.examples.clusterSanity' )
+        p.expect( self.prompt )
+        p.sendline( 'pingall' )
+        p.expect ( '(\d+)% dropped' )
+        percent = int( p.match.group( 1 ) ) if p.match else -1
+        self.assertEqual( percent, 0 )
+        p.expect( self.prompt )
+        p.sendline( 'exit' )
+        p.wait()
+
+
+if __name__  == '__main__':
+    unittest.main()


### PR DESCRIPTION
Simple sanity check(pingall) that makes sure cluster edition on one host works correctly. Included is the change from 'who am i' to $SUDO_USER, allowing us to use pexpect to test cluster edition.
