### PR TITLE
parse comments out of CLI

### DIFF
--- a/mininet/cli.py
+++ b/mininet/cli.py
@@ -395,6 +395,12 @@ class CLI( Cmd ):
                 # read data but before it has been printed.
                 node.sendInt()
 
+    def precmd( self, line ):
+        "allow for comments in the cli"
+        if '#' in line:
+            line = line.split( '#' )[ 0 ]
+        return line
+
 
 # Helper functions
 


### PR DESCRIPTION
fixes #19 

before a line is interpreted, remove any comments 

Again, not sure if we want to do this but I wanted to put it up for discussion since we have an open issue
