### PR TITLE
Switch to loxigen-built openflow.lua wireshark plugin

### DIFF
--- a/util/install.sh
+++ b/util/install.sh
@@ -216,8 +216,12 @@ function wireshark {
         $install wireshark tshark
     fi
 
+    # Copy coloring rules: OF is white-on-blue:
+    mkdir -p $HOME/.wireshark
+    cp -n $MININET_DIR/mininet/util/colorfilters $HOME/.wireshark
+
     echo "Checking Wireshark version"
-    WSVER=`wireshark -v | egrep -o '[0-9\.]+' | head -1`
+    WSVER=`wireshark -v | egrep -o -m 1 '[0-9\.]+' | head -1`
     if version_ge $WSVER 1.12; then
         echo "Wireshark version $WSVER >= 1.12 - returning"
         return
@@ -236,10 +240,6 @@ function wireshark {
     PLUGIN=loxi_output/wireshark/openflow.lua
     sudo cp $PLUGIN $WSPLUGDIR
     echo "Copied openflow plugin $PLUGIN to $WSPLUGDIR"
-
-    # Copy coloring rules: OF is white-on-blue:
-    mkdir -p $HOME/.wireshark
-    cp $MININET_DIR/mininet/util/colorfilters $HOME/.wireshark
 
     cd $BUILD_DIR
 }


### PR DESCRIPTION
The older wireshark dissectors were not well-maintained
and were a pain to build. They also added tons of extra junk
into our VM images! The ones built into the current
wireshark are deficient for 1.3. The solution for the
future is almost certainly to go with the lua-based plugin,
since it is architecture-independent and should be much
easier to maintain and upgrade.
