### PR TITLE
attach to cgroup first, then mount namespace

### DIFF
--- a/mininet/node.py
+++ b/mininet/node.py
@@ -653,8 +653,8 @@ class CPULimitedHost( Host ):
            args: Popen() args, single list, or string
            kwargs: Popen() keyword args"""
         # Tell mnexec to execute command in our cgroup
-        mncmd = [ 'mnexec', '-da', str( self.pid ),
-                  '-g', self.name ]
+        mncmd = [ 'mnexec', '-g', self.name,
+                  '-da', str( self.pid ) ]
         if self.sched == 'rt':
             mncmd += [ '-r', str( self.rtprio ) ]
         return Host.popen( self, *args, mncmd=mncmd, **kwargs )

--- a/util/m
+++ b/util/m
@@ -40,5 +40,5 @@ if [ -d $rootdir -a -x $rootdir/bin/bash ]; then
     cmd="chroot $rootdir /bin/bash -c $cmd"
 fi
 
-cmd="exec sudo mnexec -a $pid $cg $cmd"
+cmd="exec sudo mnexec $cg -a $pid $cmd"
 eval $cmd


### PR DESCRIPTION
While running mininet with CPULimitedHosts, if we run the popen command, an error occurs: `cgroup: could not add to cgroup h1`.

This happens when we attach the new process to its calling host's mount namespace, and the cgroup directory for that host is no longer visible. This is because we mount the cgroup file system at `/sys/fs/cgroup` in the root namespace and then remount `/sys` in the host namespace.

This fix simply reorders arguments passed to the `mnexec` command so that we attach to the cgroup first. We may want to rethink this in the future. possible alternatives:
1. We may also be able to share the cgroup directories over mount namespaces. currently, this will not work because we remount /sys after creating a network namespace.
2. We can reorder mnexec to make sure we attach to a cgroup before we attach to a mount namespace if both options are in the same mnexec command
3. We could try to remount cgroups after remounting `/sys` in `mnexec`. 
