### PR TITLE
removing typo in test_linearbandwidth

### DIFF
--- a/examples/test/test_linearbandwidth.py
+++ b/examples/test/test_linearbandwidth.py
@@ -31,7 +31,7 @@ class testLinearBandwidth( unittest.TestCase ):
                 elif unit[ 0 ] == 'M':
                     bw *= 10 ** 6
                 elif unit[ 0 ] == 'G':
-                    bw *= 10 ** 9a
+                    bw *= 10 ** 9
                 # check that we have a previous result to compare to
                 if n != 1:
                     self.assertTrue( bw < previous_bw )


### PR DESCRIPTION
This must have crept in there when I wrote the comment... 
