### PR TITLE
use node.pexec() to update IP address of intf instead of node.cmd()

### DIFF
--- a/mininet/link.py
+++ b/mininet/link.py
@@ -86,7 +86,9 @@ class Intf( object ):
 
     def updateIP( self ):
         "Return updated IP address based on ifconfig"
-        ifconfig = self.ifconfig()
+        # use pexec instead of node.cmd so that we dont read
+        # backgrounded output from the cli.
+        ifconfig, _err, _exitCode = self.node.pexec( 'ifconfig %s' % self.name )
         ips = self._ipMatchRegex.findall( ifconfig )
         self.ip = ips[ 0 ] if ips else None
         return self.ip


### PR DESCRIPTION
intf.updateIP() runs a command in the node that is being evaluated. This exposes it to the condition described in #403. Using node.pexec() in intf.updateIP() avoids this problem because we do not read from the same fd. 

fixes #403 
