### PR TITLE
wait for sshd to start in baresshd example

### DIFF
--- a/examples/baresshd.py
+++ b/examples/baresshd.py
@@ -4,9 +4,10 @@
 
 import sys
 from mininet.node import Host
-from mininet.util import ensureRoot
+from mininet.util import ensureRoot, waitListening
 
 ensureRoot()
+timeout = 5
 
 print "*** Creating nodes"
 h1 = Host( 'h1' )
@@ -33,5 +34,10 @@ cmd = '/usr/sbin/sshd -o UseDNS=no -u0 -o "Banner /tmp/%s.banner"' % h1.name
 if len( sys.argv ) > 1:
     cmd += ' ' + ' '.join( sys.argv[ 1: ] )
 h1.cmd( cmd )
+listening = waitListening( server=h1, port=22, timeout=timeout )
 
-print "*** You may now ssh into", h1.name, "at", h1.IP()
+if listening:
+    print "*** You may now ssh into", h1.name, "at", h1.IP()
+else:
+    print ( "*** Warning: after %s seconds, %s is not listening on port 22"
+            % ( timeout, h1.name ) )

--- a/examples/test/test_baresshd.py
+++ b/examples/test/test_baresshd.py
@@ -6,21 +6,18 @@ Tests for baresshd.py
 
 import unittest
 import pexpect
-from time import sleep
 from mininet.clean import cleanup, sh
 
 class testBareSSHD( unittest.TestCase ):
 
-    opts = [ '\(yes/no\)\?', 'Welcome to h1', 'refused', pexpect.EOF, pexpect.TIMEOUT ]
+    opts = [ 'Welcome to h1', pexpect.EOF, pexpect.TIMEOUT ]
 
     def connected( self ):
         "Log into ssh server, check banner, then exit"
-        p = pexpect.spawn( 'ssh 10.0.0.1 -i /tmp/ssh/test_rsa exit' )
+        p = pexpect.spawn( 'ssh 10.0.0.1 -o StrictHostKeyChecking=no -i /tmp/ssh/test_rsa exit' )
         while True:
             index = p.expect( self.opts )
             if index == 0:
-                p.sendline( 'yes' )
-            elif index == 1:
                 return True
             else:
                 return False
@@ -37,18 +34,23 @@ class testBareSSHD( unittest.TestCase ):
         cmd = ( 'python -m mininet.examples.baresshd '
                 '-o AuthorizedKeysFile=/tmp/ssh/authorized_keys '
                 '-o StrictModes=no' )
-        sh( cmd )
+        p = pexpect.spawn( cmd )
+        runOpts = [ 'You may now ssh into h1 at 10.0.0.1',
+                    'after 5 seconds, h1 is not listening on port 22', 
+                    pexpect.EOF, pexpect.TIMEOUT ]
+        while True:
+            index = p.expect( runOpts )
+            if index == 0:
+                break
+            else:
+                self.tearDown()
+                self.fail( 'sshd failed to start in host h1' )
 
     def testSSH( self ):
         "Simple test to verify that we can ssh into h1"
         result = False
         # try to connect up to 3 times; sshd can take a while to start
-        for _ in range( 3 ):
-            result = self.connected()
-            if result:
-                break
-            else:
-                sleep( 1 )
+        result = self.connected()
         self.assertTrue( result )
 
     def tearDown( self ):

--- a/mininet/util.py
+++ b/mininet/util.py
@@ -543,7 +543,8 @@ def ensureRoot():
     return
 
 def waitListening( client=None, server='127.0.0.1', port=80, timeout=None ):
-    "Wait until server is listening on port"
+    """Wait until server is listening on port.
+       returns True if server is listening"""
     run = ( client.cmd if client else
                 partial( quietRun, shell=True ) )
     if not run( 'which telnet' ):
@@ -554,12 +555,13 @@ def waitListening( client=None, server='127.0.0.1', port=80, timeout=None ):
     time = 0
     while 'Connected' not in run( cmd ):
         if timeout:
+            print time
             if time >= timeout:
                 error( 'could not connect to %s on port %d\n'
                        % ( server, port ) )
-                break
+                return False
         output('waiting for', server,
                'to listen on port', port, '\n')
         sleep( .5 )
         time += .5
-
+    return True


### PR DESCRIPTION
Precise32 is failing when running baresshd. This may be because sshd has not started when we try to ssh into h1. In this pull request we wait until sshd has started, or we fail the test with a message when expect times out waiting for the server to start.
