### PR TITLE
wrap the title string in quotes so that bash interprets it correctly

### DIFF
--- a/mininet/term.py
+++ b/mininet/term.py
@@ -41,7 +41,7 @@ def makeTerm( node, title='Node', term='xterm', display=None ):
        title: base title
        term: 'xterm' or 'gterm'
        returns: two Popen objects, tunnel and terminal"""
-    title += ': ' + node.name
+    title = '"%s: %s"' % ( title, node.name )
     if not node.inNamespace:
         title += ' (root)'
     cmds = {


### PR DESCRIPTION
This should fix the xterm issue in cluster edition. The issue with ssh control paths may cause this command to hang, so we may not always have success opening up a remote xterm. This is an independent issue though
