### PR TITLE
use rcmd instead of quietRun when shutting down remote nodes

### DIFF
--- a/examples/cluster.py
+++ b/examples/cluster.py
@@ -255,6 +255,13 @@ class RemoteMixin( object ):
         return super( RemoteMixin, self).addIntf( *args,
                         moveIntfFn=RemoteLink.moveIntf, **kwargs )
 
+    def cleanup( self ):
+        "Help python collect its garbage."
+        # Intfs may end up in root NS
+        for intfName in self.intfNames():
+            if self.name in intfName:
+                self.rcmd( 'ip link del ' + intfName )
+        self.shell = None
 
 class RemoteNode( RemoteMixin, Node ):
     "A node on a remote server"


### PR DESCRIPTION
fixes #441 
When using quietRun, we do not actually delete root interfaces on a remote Node because the command is only run locally.

This exposes another issue with rcmd, which seems to be taking upwards of 10 seconds to run a command and return it's output. This is a separate issue, which I have opened with #442
