### PR TITLE
IVSSwitch: turn off verbose logging by default

### DIFF
--- a/mininet/node.py
+++ b/mininet/node.py
@@ -1208,7 +1208,7 @@ class OVSBridge( OVSSwitch ):
 class IVSSwitch(Switch):
     """IVS virtual switch"""
 
-    def __init__( self, name, verbose=True, **kwargs ):
+    def __init__( self, name, verbose=False, **kwargs ):
         Switch.__init__( self, name, **kwargs )
         self.verbose = verbose
 


### PR DESCRIPTION
Most users don't need this much logging and it slows down the switch.

This doesn't fix the really excessive latency seen with the reference controller. I tracked that down to the -v flag being passed to the controller. When the controller logs a packet-out message it forks off tcpdump to parse the packet, which takes several milliseconds. This only affects IVS because we don't support buffering packets. For other switches the controller would not need to send a packet-out message.

I also fixed a related issue in https://github.com/floodlight/ivs/pull/224. The reference controller never sent a barrier to commit its flow-mods, so all traffic was using packet-in/packet-out.
