### PR TITLE
use ControlPersist ssh option to fix ControlPath shutdown

### DIFF
--- a/examples/cluster.py
+++ b/examples/cluster.py
@@ -135,7 +135,8 @@ class RemoteMixin( object ):
             self.sshcmd = [ 'sudo', '-E', '-u', self.user ] + self.sshbase
             if self.controlPath:
                 self.sshcmd += [ '-o', 'ControlPath=' + self.controlPath,
-                                 '-o', 'ControlMaster=auto' ]
+                                 '-o', 'ControlMaster=auto',
+                                 '-o', 'ControlPersist=' + '1' ]
             self.sshcmd = self.sshcmd + [ self.dest ]
             self.isRemote = True
         else:


### PR DESCRIPTION
This allows us to kill nodes individually without worrying about killing the ControlMaster session.

The shortest timeout that we can specify in ControlPersist is 1 second.

fixes #430 
