### PR TITLE
Support for running arbitrary command when starting terminal

### DIFF
--- a/mininet/term.py
+++ b/mininet/term.py
@@ -35,7 +35,7 @@ def tunnelX11( node, display=None):
                 "EXEC:'mnexec -a 1 socat STDIO %s'" % connection ]
     return 'localhost:' + screen, node.popen( cmd )
 
-def makeTerm( node, title='Node', term='xterm', display=None ):
+def makeTerm( node, title='Node', term='xterm', display=None, cmd='bash'):
     """Create an X11 tunnel to the node and start up a terminal.
        node: Node object
        title: base title
@@ -54,7 +54,7 @@ def makeTerm( node, title='Node', term='xterm', display=None ):
     display, tunnel = tunnelX11( node, display )
     if display is None:
         return []
-    term = node.popen( cmds[ term ] + [ display, '-e', 'env TERM=ansi bash'] )
+    term = node.popen( cmds[ term ] + [ display, '-e', 'env TERM=ansi %s' % cmd ] )
     return [ tunnel, term ] if tunnel else [ term ]
 
 def runX11( node, cmd ):


### PR DESCRIPTION
This change allows the user to start an xterm with an specific command rather than bash (still the default). This is helpful in running fully automated experiments using python when the commands running on the hosts require access to a TTY. 