### PR TITLE
Batch startup support for OVS

### DIFF
--- a/bin/mn
+++ b/bin/mn
@@ -41,7 +41,8 @@ from functools import partial
 # Experimental! cluster edition prototype
 from mininet.examples.cluster import ( MininetCluster, RemoteHost,
                                        RemoteOVSSwitch, RemoteLink,
-                                       SwitchBinPlacer, RandomPlacer )
+                                       SwitchBinPlacer, RandomPlacer,
+                                       ClusterCleanup )
 from mininet.examples.clustercli import ClusterCLI
 
 PLACEMENT = { 'block': SwitchBinPlacer, 'random': RandomPlacer }
@@ -281,6 +282,11 @@ class MininetRunner( object ):
     def begin( self ):
         "Create and run mininet."
 
+        if self.options.cluster:
+            servers = self.options.cluster.split( ',' )
+            for server in servers:
+                ClusterCleanup.add( server )
+
         if self.options.clean:
             cleanup()
             exit()
@@ -334,7 +340,7 @@ class MininetRunner( object ):
             warn( '*** WARNING: Experimental cluster mode!\n'
                   '*** Using RemoteHost, RemoteOVSSwitch, RemoteLink\n' )
             host, switch, link = RemoteHost, RemoteOVSSwitch, RemoteLink
-            Net = partial( MininetCluster, servers=cluster.split( ',' ),
+            Net = partial( MininetCluster, servers=servers,
                            placement=PLACEMENT[ self.options.placement ] )
 
         mn = Net( topo=topo,

--- a/bin/mn
+++ b/bin/mn
@@ -27,7 +27,7 @@ from mininet.net import Mininet, MininetWithControlNet, VERSION
 from mininet.node import ( Host, CPULimitedHost, Controller, OVSController,
                            RYU, NOX, RemoteController, findController,
                            DefaultController,
-                           UserSwitch, OVSSwitch, OVSBridge, OVSBatch,
+                           UserSwitch, OVSSwitch, OVSBridge,
                            OVSLegacyKernelSwitch, IVSSwitch )
 from mininet.nodelib import LinuxBridge
 from mininet.link import Link, TCLink, OVSLink
@@ -62,7 +62,6 @@ SWITCHES = { 'user': UserSwitch,
              # Keep ovsk for compatibility with 2.0
              'ovsk': OVSSwitch,
              'ovsl': OVSLegacyKernelSwitch,
-             'ovsbatch': OVSBatch,  # experimental!!'
              'ivs': IVSSwitch,
              'lxbr': LinuxBridge,
              'default': OVSSwitch }

--- a/bin/mn
+++ b/bin/mn
@@ -27,7 +27,7 @@ from mininet.net import Mininet, MininetWithControlNet, VERSION
 from mininet.node import ( Host, CPULimitedHost, Controller, OVSController,
                            RYU, NOX, RemoteController, findController,
                            DefaultController,
-                           UserSwitch, OVSSwitch, OVSBridge,
+                           UserSwitch, OVSSwitch, OVSBridge, OVSBatch,
                            OVSLegacyKernelSwitch, IVSSwitch )
 from mininet.nodelib import LinuxBridge
 from mininet.link import Link, TCLink, OVSLink
@@ -62,6 +62,7 @@ SWITCHES = { 'user': UserSwitch,
              # Keep ovsk for compatibility with 2.0
              'ovsk': OVSSwitch,
              'ovsl': OVSLegacyKernelSwitch,
+             'ovsbatch': OVSBatch,  # experimental!!'
              'ivs': IVSSwitch,
              'lxbr': LinuxBridge,
              'default': OVSSwitch }

--- a/examples/cluster.py
+++ b/examples/cluster.py
@@ -280,6 +280,11 @@ class RemoteOVSSwitch( RemoteMixin, OVSSwitch ):
 
     OVSVersions = {}
 
+    def __init__( self, *args, **kwargs ):
+        # No batch startup yet
+        kwargs.update( batch=False )
+        super( RemoteOVSSwitch, self ).__init__( *args, **kwargs )
+
     def isOldOVS( self ):
         "Is remote switch using an old OVS version?"
         cls = type( self )
@@ -293,9 +298,14 @@ class RemoteOVSSwitch( RemoteMixin, OVSSwitch ):
                  StrictVersion( '1.10' ) )
 
     @classmethod
+    def batchStartup( cls, *_args, **_kwargs ):
+        "Not implemented yet"
+        return []  # no switches started
+
+    @classmethod
     def batchShutdown( cls, *_args, **_kwargs ):
         "Not implemented yet"
-        return False
+        return []  # no switchest stopped
 
 
 class RemoteLink( Link ):

--- a/examples/controlnet.py
+++ b/examples/controlnet.py
@@ -27,10 +27,16 @@ from mininet.log import setLogLevel, info
 
 class DataController( Controller ):
     """Data Network Controller.
-       patched to avoid checkListening error"""
+       patched to avoid checkListening error and to delete intfs"""
+    
     def checkListening( self ):
         "Ignore spurious error"
         pass
+
+    def stop( self, *args, **kwargs ):
+        "Make sure intfs are deleted"
+        kwargs.update( deleteIntfs=True )
+        super( Controller, self ).stop( *args, **kwargs )
 
 class MininetFacade( object ):
     """Mininet object facade that allows a single CLI to

--- a/examples/sshd.py
+++ b/examples/sshd.py
@@ -39,7 +39,7 @@ def connectToRootNS( network, switch, ip, routes ):
       routes: host networks to route to"""
     # Create a node in root namespace and link to switch 0
     root = Node( 'root', inNamespace=False )
-    intf = Link( root, switch ).intf1
+    intf = network.addLink( root, switch ).intf1
     root.setIP( ip, intf=intf )
     # Start network that now includes link to root namespace
     network.start()

--- a/examples/tree1024.py
+++ b/examples/tree1024.py
@@ -9,10 +9,10 @@ and running sysctl -p. Check util/sysctl_addon.
 
 from mininet.cli import CLI
 from mininet.log import setLogLevel
-from mininet.node import OVSKernelSwitch
+from mininet.node import OVSSwitch
 from mininet.topolib import TreeNet
 
 if __name__ == '__main__':
     setLogLevel( 'info' )
-    network = TreeNet( depth=2, fanout=32, switch=OVSKernelSwitch )
+    network = TreeNet( depth=2, fanout=32, switch=OVSSwitch )
     network.run( CLI, network )

--- a/mininet/link.py
+++ b/mininet/link.py
@@ -197,9 +197,10 @@ class Intf( object ):
     def delete( self ):
         "Delete interface"
         self.cmd( 'ip link del ' + self.name )
-        if self.node.inNamespace:
-            # Link may have been dumped into root NS
-            quietRun( 'ip link del ' + self.name )
+        # We used to do this, but it slows us down:
+        # if self.node.inNamespace:
+        # Link may have been dumped into root NS
+        # quietRun( 'ip link del ' + self.name )
 
     def status( self ):
         "Return intf status as a string"

--- a/mininet/net.py
+++ b/mininet/net.py
@@ -485,9 +485,11 @@ class Mininet( object ):
         for swclass, switches in groupby(
             sorted( self.switches, key=type ), type ):
             switches = tuple( switches )
-            if ( hasattr( swclass, 'batchStartup' ) and
-                swclass.batchStartup( switches ) ):
-                started.update( { s: s for s in switches } )
+            if hasattr( swclass, 'batchStartup' ):
+                print "STARTING", switches
+                success = swclass.batchStartup( switches )
+                print "STARTED", success
+                started.update( { s: s for s in success } )
         info( '\n' )
         if self.waitConn:
             self.waitConnected()
@@ -512,9 +514,9 @@ class Mininet( object ):
         for swclass, switches in groupby(
                 sorted( self.switches, key=type ), type ):
             switches = tuple( switches )
-            if ( hasattr( swclass, 'batchShutdown' ) and
-                 swclass.batchShutdown( switches ) ):
-                stopped.update( { s: s for s in switches } )
+            if hasattr( swclass, 'batchShutdown' ):
+                success = swclass.batchShutdown( switches )
+                stopped.update( { s: s for s in success } )
         for switch in self.switches:
             info( switch.name + ' ' )
             if switch not in stopped:

--- a/mininet/net.py
+++ b/mininet/net.py
@@ -481,6 +481,13 @@ class Mininet( object ):
         for switch in self.switches:
             info( switch.name + ' ')
             switch.start( self.controllers )
+        started = {}
+        for swclass, switches in groupby(
+            sorted( self.switches, key=type ), type ):
+            switches = tuple( switches )
+            if ( hasattr( swclass, 'batchStartup' ) and
+                swclass.batchStartup( switches ) ):
+                started.update( { s: s for s in switches } )
         info( '\n' )
         if self.waitConn:
             self.waitConnected()

--- a/mininet/net.py
+++ b/mininet/net.py
@@ -486,9 +486,7 @@ class Mininet( object ):
             sorted( self.switches, key=type ), type ):
             switches = tuple( switches )
             if hasattr( swclass, 'batchStartup' ):
-                print "STARTING", switches
                 success = swclass.batchStartup( switches )
-                print "STARTED", success
                 started.update( { s: s for s in success } )
         info( '\n' )
         if self.waitConn:

--- a/mininet/net.py
+++ b/mininet/net.py
@@ -414,7 +414,12 @@ class Mininet( object ):
 
         info( '\n*** Adding switches:\n' )
         for switchName in topo.switches():
-            self.addSwitch( switchName, **topo.nodeInfo( switchName) )
+            # A bit ugly: add batch parameter if appropriate
+            params = topo.nodeInfo( switchName)
+            cls = params.get( 'cls', self.switch )
+            if hasattr( cls, 'batchStartup' ):
+                params.setdefault( 'batch', True )
+            self.addSwitch( switchName, **params )
             info( switchName + ' ' )
 
         info( '\n*** Adding links:\n' )

--- a/mininet/node.py
+++ b/mininet/node.py
@@ -258,9 +258,9 @@ class Node( object ):
         """Send a command, followed by a command to echo a sentinel,
            and return without waiting for the command to complete.
            args: command and arguments, or string
-           printPid: print command's PID?"""
+           printPid: print command's PID? (False)"""
         assert self.shell and not self.waiting
-        printPid = kwargs.get( 'printPid', True )
+        printPid = kwargs.get( 'printPid', False )
         # Allow sendCmd( [ list ] )
         if len( args ) == 1 and isinstance( args[ 0 ], list ):
             cmd = args[ 0 ]

--- a/mininet/node.py
+++ b/mininet/node.py
@@ -157,8 +157,7 @@ class Node( object ):
                 break
             self.pollOut.poll()
         self.waiting = False
-        self.cmd( 'stty -echo' )
-        self.cmd( 'set +m' )
+        self.cmd( 'stty -echo; set +m' )
 
     def mountPrivateDirs( self ):
         "mount private directories"
@@ -1270,7 +1269,7 @@ class OVSSwitch( Switch ):
     def batchShutdown( cls, switches, run=errRun ):
         "Shut down a list of OVS switches"
         delcmd = 'del-br %s'
-        if not cls.isOldOVS():
+        if switches and not switches[ 0 ].isOldOVS():
             delcmd = '--if-exists ' + delcmd
         # First, delete them all from ovsdb
         run( 'ovs-vsctl ' +
@@ -1549,4 +1548,4 @@ def DefaultController( name, controllers=DefaultControllers, **kwargs ):
     controller = findController( controllers )
     if not controller:
         raise Exception( 'Could not find a default OpenFlow controller' )
-    return contr
+    return controller( name, **kwargs )

--- a/mininet/node.py
+++ b/mininet/node.py
@@ -1273,8 +1273,6 @@ class OVSBridge( OVSSwitch ):
 class OVSBatch( OVSSwitch ):
     "Experiment: batch startup of OVS switches"
 
-    reconnectms = 1000  # shared for all switches
-    
     # This should be ~ int( quietRun( 'getconf ARG_MAX' ) ),
     # but the real limit seems to be much lower
     argmax = 128000
@@ -1282,11 +1280,6 @@ class OVSBatch( OVSSwitch ):
     def __init__( self, *args, **kwargs ):
         self.commands = []
         self.started = False
-        # Use global rather than local reconnectms
-        reconnectms = kwargs.pop( 'reconnectms', 1000 )
-        self.__class__.reconnectms = max( reconnectms,
-                                          self.__class__.reconnectms )
-        kwargs.update( reconnectms=None )
         super( OVSBatch, self ).__init__( *args, **kwargs )
 
     @classmethod
@@ -1316,6 +1309,14 @@ class OVSBatch( OVSSwitch ):
         cmd = ' '.join( str( arg ).strip() for arg in args )
         self.commands.append( cmd )
 
+    def start( self, *args, **kwargs ):
+        super( OVSBatch, self ).start( *args, **kwargs )
+        self.started = True
+ 
+    def stop( self, *args, **kwargs ):
+        super( OVSBatch, self ).stop( *args, **kwargs )
+        self.started = False
+         
     def cleanup( self):
         "Don't bother to clean up"
         return

--- a/mininet/node.py
+++ b/mininet/node.py
@@ -1299,7 +1299,7 @@ class OVSBatch( OVSSwitch ):
     def vsctl( self, *args, **kwargs ):
         "Append ovs-vsctl command to list for later execution"
         if self.started:
-            return super( OVSBridge, self).vsctl( *args, **kwargs )
+            return super( OVSBatch, self).vsctl( *args, **kwargs )
         cmd = ' '.join( str( arg ).strip() for arg in args )
         self.commands.append( cmd )
 

--- a/mininet/node.py
+++ b/mininet/node.py
@@ -194,10 +194,11 @@ class Node( object ):
 
     def cleanup( self ):
         "Help python collect its garbage."
+        # We used to do this, but it slows us down:
         # Intfs may end up in root NS
-        for intfName in self.intfNames():
-            if self.name in intfName:
-                quietRun( 'ip link del ' + intfName )
+        # for intfName in self.intfNames():
+        # if self.name in intfName:
+        # quietRun( 'ip link del ' + intfName )
         self.shell = None
 
     # Subshell I/O, commands and control
@@ -1311,10 +1312,6 @@ class OVSBatch( OVSSwitch ):
         super( OVSBatch, self ).stop( *args, **kwargs )
         self.started = False
          
-    def cleanup( self):
-        "Don't bother to clean up"
-        return
-
 
 class IVSSwitch( Switch ):
     "Indigo Virtual Switch"

--- a/mininet/node.py
+++ b/mininet/node.py
@@ -1058,7 +1058,7 @@ class OVSSwitch( Switch ):
 
     def __init__( self, name, failMode='secure', datapath='kernel',
                   inband=False, protocols=None,
-                  reconnectms=1000, stp=False, batch=True, **params ):
+                  reconnectms=1000, stp=False, batch=False, **params ):
         """name: name for switch
            failMode: controller loss behavior (secure|open)
            datapath: userspace or kernel mode (kernel|user)
@@ -1067,7 +1067,7 @@ class OVSSwitch( Switch ):
                       Unspecified (or old OVS version) uses OVS default
            reconnectms: max reconnect timeout in ms (0/None for default)
            stp: enable STP (False, requires failMode=standalone)
-           batch: enable batch startup (True)"""
+           batch: enable batch startup (False)"""
         Switch.__init__( self, name, **params )
         self.failMode = failMode
         self.datapath = datapath

--- a/mininet/node.py
+++ b/mininet/node.py
@@ -1178,7 +1178,7 @@ class OVSSwitch( Switch ):
         if not self.inband:
             opts += ' other-config:disable-in-band=true'
         if self.datapath == 'user':
-            opts += ' datapath_type=netdev' % self
+            opts += ' datapath_type=netdev'
         if self.protocols and not self.isOldOVS():
             opts += ' protocols=%s' % ( self, self.protocols )
         if self.stp and self.failMode == 'standalone':

--- a/mininet/node.py
+++ b/mininet/node.py
@@ -1280,7 +1280,7 @@ class OVSBatch( OVSSwitch ):
     def batchStartup( cls, switches ):
         "Batch startup for OVS"
         info( '...' )
-        cmds = 'ovs-vsctl '
+        cmds = 'ovs-vsctl'
         for switch in switches:
             if cls.isOldOVS():
                 quietRun( 'ovs-vsctl del-br %s' % switch )

--- a/mininet/util.py
+++ b/mininet/util.py
@@ -77,6 +77,7 @@ def errRun( *cmd, **kwargs ):
         cmd = [ str( arg ) for arg in cmd ]
     elif isinstance( cmd, list ) and shell:
         cmd = " ".join( arg for arg in cmd )
+    debug( '*** errRun:', cmd, '\n' )
     popen = Popen( cmd, stdout=PIPE, stderr=stderr, shell=shell )
     # We use poll() because select() doesn't work with large fd numbers,
     # and thus communicate() doesn't work either

--- a/mininet/util.py
+++ b/mininet/util.py
@@ -114,6 +114,7 @@ def errRun( *cmd, **kwargs ):
                 poller.unregister( fd )
 
     returncode = popen.wait()
+    debug( out, err, returncode )
     return out, err, returncode
 
 def errFail( *cmd, **kwargs ):

--- a/mininet/util.py
+++ b/mininet/util.py
@@ -190,7 +190,8 @@ def makeIntfPair( intf1, intf2, addr1=None, addr2=None, node1=None, node2=None,
     if cmdOutput == '':
         return True
     else:
-        error( "Error creating interface pair: %s " % cmdOutput )
+        raise Exception( "Error creating interface pair (%s,%s): %s " %
+                         ( intf1, intf2, cmdOutput ) )
         return False
 
 def retry( retries, delaySecs, fn, *args, **keywords ):


### PR DESCRIPTION
Currently, every `ovs-vsctl` command requires reading the entire OVS configuration database. This means that its performance gets linearly slower as more switches and ports are added. To mitigate this, we batch multiple configuration operations into individual, long, `ovs-vsctl` commands.

This patch set makes a couple of other notable changes, including setting `printPid=False` by default (avoids using `mnexec` unnecessarily) and running certain commands using `errRun` rather than `quietRun`. Additionally we no longer look for leftover links in the root namespace, so code relying on that functionality may have to change slightly (as in `controlnet.py` and `sshd.py` for example.) It also adds cluster support to `mn -c`.

The performance result is that `mn --topo linear,200 --test none` now completes in 60 seconds rather than 95 seconds (on my laptop) without the patch (vs. 101 seconds in 2.2.0).

This is still slower than I would like - we should be able to make some additional improvements.