### PR TITLE
set hostname of namespaced nodes

### DIFF
--- a/mininet/node.py
+++ b/mininet/node.py
@@ -51,6 +51,7 @@ import pty
 import re
 import signal
 import select
+import pipes
 from subprocess import Popen, PIPE
 from time import sleep
 
@@ -99,6 +100,7 @@ class Node( object ):
         # Start command interpreter shell
         self.startShell()
         self.mountPrivateDirs()
+        self.setHostname()
 
     # File descriptor to node mapping support
     # Class variables and methods
@@ -183,6 +185,11 @@ class Node( object ):
                 self.cmd( 'umount ', directory[ 0 ] )
             else:
                 self.cmd( 'umount ', directory )
+
+    def setHostname( self ):
+        "Set the hostname to the node name"
+        if self.inNamespace:
+            self.cmd( 'hostname %s' % pipes.quote( self.name ) )
 
     def _popen( self, cmd, **params ):
         """Internal method: spawn and return a process

--- a/mnexec.c
+++ b/mnexec.c
@@ -5,7 +5,7 @@
  *
  *  - closing all file descriptors except stdin/out/error
  *  - detaching from a controlling tty using setsid
- *  - running in network and mount namespaces
+ *  - running in network, mount, and UTS namespaces
  *  - printing out the pid of a process so we can identify it later
  *  - attaching to a namespace and cgroup
  *  - setting RT scheduling
@@ -36,9 +36,9 @@ void usage(char *name)
            "Options:\n"
            "  -c: close all file descriptors except stdin/out/error\n"
            "  -d: detach from tty by calling setsid()\n"
-           "  -n: run in new network and mount namespaces\n"
+           "  -n: run in new network, mount, and UTS namespaces\n"
            "  -p: print ^A + pid\n"
-           "  -a pid: attach to pid's network and mount namespaces\n"
+           "  -a pid: attach to pid's network, mount, and UTS namespaces\n"
            "  -g group: add to cgroup\n"
            "  -r rtprio: run with SCHED_RR (usually requires -g)\n"
            "  -v: print version\n",
@@ -125,8 +125,8 @@ int main(int argc, char *argv[])
             setsid();
             break;
         case 'n':
-            /* run in network and mount namespaces */
-            if (unshare(CLONE_NEWNET|CLONE_NEWNS) == -1) {
+            /* run in network, mount, and UTS namespaces */
+            if (unshare(CLONE_NEWNET|CLONE_NEWNS|CLONE_NEWUTS) == -1) {
                 perror("unshare");
                 return 1;
             }
@@ -168,6 +168,17 @@ int main(int argc, char *argv[])
             /* chdir to correct working directory */
             if (chdir(cwd) != 0) {
                 perror(cwd);
+                return 1;
+            }
+            /* Attach to pid's UTS namespace */
+            sprintf(path, "/proc/%d/ns/uts", pid);
+            nsid = open(path, O_RDONLY);
+            if (nsid < 0) {
+                perror(path);
+                return 1;
+            }
+            if (setns(nsid, 0) != 0) {
+                perror("setns");
                 return 1;
             }
             break;


### PR DESCRIPTION
Some programs like lldpd and IVS send the hostname in LLDPs, OpenFlow messages, etc. For debugging purposes it's nice to get the Mininet node name in these messages rather than the host's hostname. The UTS namespaces I added to mnexec isolate just the hostname and domain name.