### PR TITLE
Add Natted() and natted() for easy natted topologies

### DIFF
--- a/mininet/topolib.py
+++ b/mininet/topolib.py
@@ -1,6 +1,7 @@
 "Library of potentially useful topologies for Mininet"
 
 from mininet.topo import Topo
+from mininet.nodelib import NAT
 from mininet.net import Mininet
 
 # The build() method is expected to do this:
@@ -68,5 +69,32 @@ class TorusTopo( Topo ):
                 sw3 = switches[ ( i + 1 ) % x, j ]
                 self.addLink( sw1, sw2 )
                 self.addLink( sw1, sw3 )
+
+def Natted( topoClass ):
+    "Return a natted Topo class based on topoClass"
+    class NattedTopo( topoClass ):
+        "Customized topology with attached NAT"
+        def build( self, *args, **kwargs ):
+            """Build topo with NAT attachment
+                natIP: local IP address of NAT node for routing ('10.0.0.254')
+                connect: switch to connect NAT node to ('s1')"""
+            self.natIP = kwargs.pop( 'natIP', '10.0.0.254')
+            self.connect = kwargs.pop( 'connect', 's1' )
+            self.hopts.update( defaultRoute='via ' + self.natIP )
+            super( NattedTopo, self ).build( *args, **kwargs )
+            nat1 = self.addNode( 'nat1', cls=NAT, ip=self.natIP,
+                                inNamespace=False )
+            self.addLink( self.connect, nat1 )
+    return NattedTopo
+
+
+def natted( topoClass, *args, **kwargs ):
+    """Create and invoke natted version of topoClass
+        natIP: local IP address of NAT node for routing ('10.0.0.254')
+        connect: switch to connect NAT node to ('s1')
+        usage: topo = natted( TreeTopo, depth=2, fanout=2 )"""
+    topoClass = Natted( topoClass )
+    return topoClass( *args, **kwargs )
+
 
 # pylint: enable=arguments-differ


### PR DESCRIPTION
Someone on the mailing list asked about adding a NAT to a topology.

Although we can add a nat using `Mininet.addNAT().configDefault()` (which seems a bit inconvenient), we can also add one in the topology itself, e.g.

`net = Mininet( topo=natted( TreeTopo, depth=2, fanout=2 ) )`

The advantage of doing it in the topology is that it can be done in a custom file. Though... then you could just use `--nat`, which does the same thing.

I'm a bit unsure of the right API for this. Maybe we just want

`net = Mininet( topo=..., nat={natopts})`

Anyway let me know what you think.