### PR TITLE
New netbee lib, fixes need for very old bison

### DIFF
--- a/util/install.sh
+++ b/util/install.sh
@@ -189,11 +189,17 @@ function of13 {
     fi
 
     # Install netbee
-    NBEESRC="nbeesrc-feb-24-2015"
+    if [ "$DIST" = "Ubuntu" ] && version_ge $RELEASE 14.04; then
+        NBEESRC="nbeesrc-feb-24-2015"
+        NBEEDIR="netbee"
+    else
+        NBEESRC="nbeesrc-jan-10-2013"
+        NBEEDIR="nbeesrc-jan-10-2013"
+    fi
+
     NBEEURL=${NBEEURL:-http://www.nbee.org/download/}
     wget -nc ${NBEEURL}${NBEESRC}.zip
     unzip ${NBEESRC}.zip
-    NBEEDIR=netbee
     cd ${NBEEDIR}/src
     cmake .
     make

--- a/util/install.sh
+++ b/util/install.sh
@@ -189,17 +189,18 @@ function of13 {
     fi
 
     # Install netbee
-    NBEESRC="nbeesrc-jan-10-2013"
+    NBEESRC="nbeesrc-feb-24-2015"
     NBEEURL=${NBEEURL:-http://www.nbee.org/download/}
     wget -nc ${NBEEURL}${NBEESRC}.zip
     unzip ${NBEESRC}.zip
-    cd ${NBEESRC}/src
+    NBEEDIR=netbee
+    cd ${NBEEDIR}/src
     cmake .
     make
     cd $BUILD_DIR/
-    sudo cp ${NBEESRC}/bin/libn*.so /usr/local/lib
+    sudo cp ${NBEEDIR}/bin/libn*.so /usr/local/lib
     sudo ldconfig
-    sudo cp -R ${NBEESRC}/include/ /usr/
+    sudo cp -R ${NBEEDIR}/include/ /usr/
 
     # Resume the install:
     cd $BUILD_DIR/ofsoftswitch13


### PR DESCRIPTION
OpenFlow soft switch needs the NetBee library. The previous version failed to install out of the box as it needed some very old versions of bison. A new netbee lib has become available which seems to work and installs without a fuss. Tested on Ubuntu 14.04.02