### PR TITLE
Updating mn help/man to provide more details on options

### DIFF
--- a/bin/mn
+++ b/bin/mn
@@ -65,6 +65,13 @@ SWITCHES = { 'user': UserSwitch,
              'ivs': IVSSwitch,
              'lxbr': LinuxBridge,
              'default': OVSSwitch }
+SWITCHESHELP = { 'user': 'OpenFlow reference user-space switch.',
+                 'ovs': 'Open vSwitch OpenFlow-compatible switch.',
+                 'ovsbr': 'Open vSwitch as an L2 MAC learning switch.',
+                 'ovsk': 'Same as the ovs type.',
+                 'ivs': 'Indigo Virtual Switch.',
+                 'lxbr': 'Linux Bridge.',
+                 'default': 'Open vSwitch OpenFlow-compatible switch.'}
 
 HOSTDEF = 'proc'
 HOSTS = { 'proc': Host,
@@ -96,17 +103,20 @@ ALTSPELLING = { 'pingall': 'pingAll',
                 'iperfUDP': 'iperfUdp' }
 
 
-def addDictOption( opts, choicesDict, default, name, helpStr=None, **kwargs ):
-    """Convenience function to add choices dicts to OptionParser.
-       opts: OptionParser instance
-       choicesDict: dictionary of valid choices, must include default
-       default: default choice key
-       name: long option name
-       helpStr: help string
-       kwargs: additional arguments to add_option"""
-    if not helpStr:
-        helpStr = ( '|'.join( sorted( choicesDict.keys() ) ) +
-                    '[,param=value...]' )
+def addDictOption( opts, choicesDict, default, name, helpDict=None, **kwargs ):
+    """Convenience function to add choices dicts to OptionParser.          
+       opts: OptionParser instance                                         
+       choicesDict: dictionary of valid choices, must include default      
+       default: default choice key                                         
+       name: long option name                                              
+       helpDict: dictionary describing choices
+       kwargs: additional arguments to add_option"""                       
+    helpStr = ( '|'.join( sorted( choicesDict.keys() ) ) +
+                '[,param=value...]' )
+    if helpDict:
+        helpList = [ k + "=" + helpDict[k] 
+                     for k in sorted( helpDict.keys() ) ]
+        helpStr += " " + ( ' '.join( helpList ) )
     params = dict( type='string', default=default, help=helpStr )
     params.update( **kwargs )
     opts.add_option( '--' + name, **params )
@@ -192,7 +202,7 @@ class MininetRunner( object ):
                   '(type %prog -h for details)' )
 
         opts = OptionParser( description=desc, usage=usage )
-        addDictOption( opts, SWITCHES, SWITCHDEF, 'switch' )
+        addDictOption( opts, SWITCHES, SWITCHDEF, 'switch', SWITCHESHELP )
         addDictOption( opts, HOSTS, HOSTDEF, 'host' )
         addDictOption( opts, CONTROLLERS, [], 'controller', action='append' )
         addDictOption( opts, LINKS, LINKDEF, 'link' )


### PR DESCRIPTION
This is in response to the recent question on the mailing list about mn options and Bob's comments in response about updating mn --help/man mn. The addDictOption function here now optionally accepts a help dictionary describing relevent options. If this looks OK I can add dicts for controllers, topos, links, and hosts (and include param descriptions where applicable).

![image](https://cloud.githubusercontent.com/assets/1427207/7100473/b10a3bba-dfd8-11e4-857a-6cd73c459f5e.png)
