### PR TITLE
Fixed dependency problem when running ubuntuOvs

### DIFF
--- a/util/install.sh
+++ b/util/install.sh
@@ -303,7 +303,7 @@ function ubuntuOvs {
     # Get build deps
     $install build-essential fakeroot debhelper autoconf automake libssl-dev \
              pkg-config bzip2 openssl python-all procps python-qt4 \
-             python-zopeinterface python-twisted-conch dkms
+             python-zopeinterface python-twisted-conch dkms uuid-runtime
 
     # Build OVS
     cd $BUILD_DIR/openvswitch/openvswitch-$OVS_RELEASE


### PR DESCRIPTION
openvswitch-switch depends on "uuid-runtime" in ubuntuOvs
OS: Ubuntu 14.04.1 x86_64
