### PR TITLE
Virtual Time Support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,8 +42,12 @@ slowtest: $(MININET)
 	mininet/test/test_walkthrough.py -v
 	mininet/examples/test/runner.py -v
 
-mnexec: mnexec.c $(MN) mininet/net.py
-	cc $(CFLAGS) $(LDFLAGS) -DVERSION=\"`PYTHONPATH=. $(MN) --version`\" $< -o $@
+# virtual time system calls
+syscall.o: syscall_wrapper.c
+	cc $(CFLAGS) $(LDFLAGS) -c syscall_wrapper.c
+
+mnexec: mnexec.c syscall.o $(MN) mininet/net.py
+	cc $(CFLAGS) $(LDFLAGS) -DVERSION=\"`PYTHONPATH=. $(MN) --version`\" $< syscall.o -o $@
 
 install: $(MNEXEC) $(MANPAGES)
 	install $(MNEXEC) $(BINDIR)

--- a/mininet/link.py
+++ b/mininet/link.py
@@ -224,7 +224,7 @@ class TCIntf( Intf ):
 
     # The parameters we use seem to work reasonably up to 1 Gb/sec
     # For higher data rates, we will probably need to change them.
-    bwParamMax = 1000
+    bwParamMax = 10000 # increase to 10 Gbps with virtual time
 
     def bwCmds( self, bw=None, speedup=0, use_hfsc=False, use_tbf=False,
                 latency_ms=None, enable_ecn=False, enable_red=False ):

--- a/mininet/node.py
+++ b/mininet/node.py
@@ -74,7 +74,7 @@ class Node( object ):
 
     portBase = 0  # Nodes always start with eth0/port0, even in OF 1.0
 
-    def __init__( self, name, inNamespace=True, **params ):
+    def __init__( self, name, inNamespace=True, tdf=1, **params ):
         """name: name of node
            inNamespace: in network namespace?
            privateDirs: list of private directory strings or tuples
@@ -86,6 +86,7 @@ class Node( object ):
         self.name = params.get( 'name', name )
         self.privateDirs = params.get( 'privateDirs', [] )
         self.inNamespace = params.get( 'inNamespace', inNamespace )
+        self.tdf = params.get( 'tdf', tdf)
 
         # Stash configuration parameters for future reference
         self.params = params
@@ -120,6 +121,11 @@ class Node( object ):
         node = cls.outToNode.get( fd )
         return node or cls.inToNode.get( fd )
 
+    def setTDF( self, tdf):
+        self.tdf = tdf
+        cmd = "mnexec -p -t %d " % tdf
+        out = self.cmd( cmd, printPid=True)
+
     # Command support via shell process in namespace
     def startShell( self, mnopts=None ):
         "Start a shell process for running commands"
@@ -130,7 +136,9 @@ class Node( object ):
         # (p)rint pid, and run in (n)amespace
         opts = '-cd' if mnopts is None else mnopts
         if self.inNamespace:
-            opts += 'n'
+            opts += 'n %d ' % self.tdf
+            if self.tdf != 1:
+                print "[info] %s enter virtual time with tdf = %d\n" % (self.name, self.tdf)
         # bash -i: force interactive
         # -s: pass $* to shell, and make process easy to find in ps
         # prompt is set to sentinel chr( 127 )

--- a/syscall_wrapper.c
+++ b/syscall_wrapper.c
@@ -1,0 +1,23 @@
+#include <sys/syscall.h>
+
+/*
+ * hard coded number from syscall_64.tbl
+ * depend on kernel patch
+ */
+#define VIRTUALTIMEUNSHARE 318
+#define SETTIMEDILATIONFACTOR 321
+
+int virtualtimeunshare(unsigned long flags, int dilation)
+{
+    return syscall(VIRTUALTIMEUNSHARE, flags | 0x02000000, dilation);
+}
+
+/*
+ *  ppid == 0 : change caller itself's dilation
+ *  ppid !=0 :  change caller's parent's dilation
+ */
+int settimedilationfactor(int dilation, int ppid)
+{
+	return syscall(SETTIMEDILATIONFACTOR, dilation, ppid);
+}
+

--- a/syscall_wrapper.h
+++ b/syscall_wrapper.h
@@ -1,0 +1,11 @@
+#include <stdlib.h>
+#include <stdio.h>
+
+/*
+ *	This wrapper will ease the invocation of newly added system calls
+ *	Think of it as a part of glibc
+ */
+
+int virtualtimeunshare(unsigned long, int);
+int settimedilationfactor(int, int);
+

--- a/virtual_time_commit.md
+++ b/virtual_time_commit.md
@@ -1,0 +1,31 @@
+Introduction
+============
+This very primitive patch is the result of our paper [“VT-Mininet: Virtual-time-enabled Mininet for Scalable and Accurate Software-Define Network Emulation”], to appear on [ACM Sigcomm Symposium on SDN Research (SOSR) 2015](http://opennetsummit.org/conference/sosr/).
+
+Mininet, as an examplary and ordinary network emulator, uses the system clock across all the containers, even if a container is not being scheduled to run. This leads to the issue of temporal fidelity, especially with high workloads.
+
+Virtual time sheds the light on the issue of preserving temporal fidelity for large-scale emulation. The key insight is to trade time with system resources via precisely scaling the time of interactions between containers and physical devices by a factor of N (also called time dilation factor), hence, making an emulated network appear to be N times faster from the viewpoints of applications in the container than it actually is.
+
+How to Use Virtual Time
+=======================
+When creating hosts, feed another parameter time dilation factor, "tdf". For example:
+```
+Host = custom( CPULimitedHost, sched = 'cfs', period_us = 100000, cpu = 0.8, tdf = 4 )
+......# create Class for topo, switches etc
+net = Mininet( topo = Topo, host = Host, switch = Switch, controller = Controller, waitConnected = True, link = Link )
+```
+TDF's default value is 1, e.g. no virtual time. So this patch should NOT cause compatible issues.
+
+
+Test
+====
+I test this patch on my Dell XPS 8700 Desktop running on Ubuntu 14.04 LTS. We integrated virtual time with Mininet and conducted many experimental evaluations. Details can be found in our SOSR2015 paper. There is another similar paper on PADS2015 named [A Virtual Time System for Linux-container-based Emulation of Software-defined Networks](http://www.acm-sigsim-pads.org), though it focuses on simulation & emulation system and gives more comprehensive experimental results.
+The integrated Mininet code, together with kernel patches, is also separately published at my [Github](https://github.com/littlepretty/VirtualTimeForMininet) website. In other words, to run Mininet with virtual time, one must first rebuild one's kernel. How to patch kernel is described in that repository's README file.
+
+TODO List
+=========
+1. How to provide kernel patch? Option 1: provide patch file with respect to particualr kernel version. Option 2: provide already rebuilt virtual machine  image.
+2. Summary some tests into one or two demos and place them under example diretory.
+3. If the application inside container is at a very deep position of the process tree, setTDF will need to do cascading operations so that TDF of all processes in the tee, including host and all other applications inside the container, is properly changed. This is not implemented yet.
+4. There are many other code regarding adaptive virtual time system. It is mentioned and discussed in both PADS and SOSR papers. However, it is still too immature.
+


### PR DESCRIPTION
Introduction
============
This very primitive patch is the result of our paper [“VT-Mininet: Virtual-time-enabled Mininet for Scalable and Accurate Software-Define Network Emulation”], to appear on [ACM Sigcomm Symposium on SDN Research (SOSR) 2015](http://opennetsummit.org/conference/sosr/).

Mininet, as an examplary and ordinary network emulator, uses the system clock across all the containers, even if a container is not being scheduled to run. This leads to the issue of temporal fidelity, especially with high workloads.

Virtual time sheds the light on the issue of preserving temporal fidelity for large-scale emulation. The key insight is to trade time with system resources via precisely scaling the time of interactions between containers and physical devices by a factor of N (also called time dilation factor), hence, making an emulated network appear to be N times faster from the viewpoints of applications in the container than it actually is.

How to Use Virtual Time
=======================
When creating hosts, feed another parameter time dilation factor, "tdf". For example:
```
Host = custom( CPULimitedHost, sched = 'cfs', period_us = 100000, cpu = 0.8, tdf = 4 )
......# create Class for topo, switches etc
net = Mininet( topo = Topo, host = Host, switch = Switch, controller = Controller, waitConnected = True, link = Link )
```
TDF's default value is 1, e.g. no virtual time. So this patch should NOT cause compatible issues.


Test
====
I test this patch on my Dell XPS 8700 Desktop running on Ubuntu 14.04 LTS. We integrated virtual time with Mininet and conducted many experimental evaluations. Details can be found in our SOSR2015 paper. There is another similar paper on PADS2015 named [A Virtual Time System for Linux-container-based Emulation of Software-defined Networks](http://www.acm-sigsim-pads.org), though it focuses on simulation & emulation system and gives more comprehensive experimental results.
The integrated Mininet code, together with kernel patches, is also separately published at my [Github](https://github.com/littlepretty/VirtualTimeForMininet) website. In other words, to run Mininet with virtual time, one must first rebuild one's kernel. How to patch kernel is described in that repository's README file.

TODO List
=========
1. How to provide kernel patch? Option 1: provide patch file with respect to particualr kernel version. Option 2: provide already rebuilt virtual machine  image.
2. Summary some tests into one or two demos and place them under example diretory.
3. If the application inside container is at a very deep position of the process tree, setTDF will need to do cascading operations so that TDF of all processes in the tee, including host and all other applications inside the container, is properly changed. This is not implemented yet.
4. There are many other code regarding adaptive virtual time system. It is mentioned and discussed in both PADS and SOSR papers. However, it is still too immature.
