### PR TITLE
OVS switches in shared namespaces

### DIFF
--- a/examples/multiovs.py
+++ b/examples/multiovs.py
@@ -1,0 +1,208 @@
+#!/usr/bin/python
+
+"""
+Multiple ovsdb OVS!!
+
+We scale up by creating multiple ovsdb instances,
+each of which is shared by several OVS switches
+
+Note: here is the command that is actually run to start ovsdb:
+
+ovsdb-server /etc/openvswitch/conf.db -vconsole:emer -vsyslog:err -vfile:info --remote=punix:/var/run/openvswitch/db.sock --private-key=db:Open_vSwitch,SSL,private_key --certificate=db:Open_vSwitch,SSL,certificate --bootstrap-ca-cert=db:Open_vSwitch,SSL,ca_cert --no-chdir --log-file=/var/log/openvswitch/ovsdb-server.log --pidfile=/var/run/openvswitch/ovsdb-server.pid --detach --monitor
+
+"""
+
+from mininet.net import Mininet
+from mininet.node import Node, OVSSwitch
+from mininet.node import OVSBridge
+from mininet.link import Link, OVSLink
+from mininet.topo import LinearTopo, SingleSwitchTopo
+from mininet.topolib import TreeTopo
+from mininet.log import setLogLevel, info
+from mininet.cli import CLI
+
+from itertools import groupby
+from operator import attrgetter
+
+class OVSDB( Node ):
+    "Namespace for an OVSDB instance"
+
+    privateDirs = [ '/etc/openvswitch',
+                    '/var/run/openvswitch',
+                    '/var/log/openvswitch' ]
+
+    # Control network
+    ipBase = '172.123.123.0/24'
+    cnet = None
+
+    @classmethod
+    def startControlNet( cls ):
+        "Start control net if necessary and return it"
+        cnet = cls.cnet
+        if not cnet:
+            info( '### Starting control network\n' )
+            cnet = Mininet( ipBase=cls.ipBase )
+            cswitch = cnet.addSwitch( 'ovsbr0', cls=OVSBridge )
+            root = cnet.addHost( 'root0', inNamespace=False )
+            cnet.addLink( root, cswitch )
+            cls.cnet = cnet
+            cnet.start()
+            info( '### Control network started\n' )
+        return cnet
+  
+    @classmethod
+    def rootIntf( cls ):
+        return cls.cnet[ 'root0' ].intfs[ 0 ]
+
+    def stopControlNet( self ):
+        info( '\n### Stopping control network\n' )
+        cls = self.__class__
+        cls.cnet.stop()
+        info( '### Control network stopped\n' )
+
+    def addSwitch( self, switch ):
+        "Add a switch to our namespace"
+        self.switches.append( switch )
+
+    def delSwitch( self, switch ):
+        "Delete a switch from our namespace, and terminate if none left"
+        self.switches.remove( switch )
+        if not self.switches:
+            self.stopOVS()
+
+    ovsdbCount = 0
+    
+    def startOVS( self ):
+        "Start new OVS instance"
+        self.cmd( 'ovsdb-tool create /etc/openvswitch/conf.db' )
+        self.cmd( 'ovsdb-server /etc/openvswitch/conf.db'
+                  ' -vfile:emer -vfile:err -vfile:info'
+                  ' --remote=punix:/var/run/openvswitch/db.sock '
+                  ' --log-file=/var/log/openvswitch/ovsdb-server.log'
+                  ' --pidfile=/var/run/openvswitch/ovsdb-server.pid'
+                  ' --no-chdir'
+                  ' --detach' )
+
+        self.cmd( 'ovs-vswitchd unix:/var/run/openvswitch/db.sock'
+                  ' -vfile:emer -vfile:err -vfile:info'
+                  ' --mlockall --log-file=/var/log/openvswitch/ovs-vswitchd.log'
+                  ' --pidfile=/var/run/openvswitch/ovs-vswitchd.pid'
+                  ' --no-chdir'
+                  ' --detach' )
+
+    def stopOVS( self ):
+        self.cmd( 'kill',
+                  '`cat /var/run/openvswitch/ovs-vswitchd.pid`',
+                  '`cat /var/run/openvswitch/ovsdb-server.pid`' )
+        self.cmd( 'wait' )
+        self.__class__.ovsdbCount -= 1
+        if self.__class__.ovsdbCount <= 0:
+            self.stopControlNet()
+
+    def self( self, *args, **kwargs ):
+        "A fake constructor that sets params and returns self"
+        self.params = kwargs
+        return self
+
+    def __init__( self, **kwargs ):
+        cls = self.__class__
+        cls.ovsdbCount += 1
+        cnet = self.startControlNet()
+        # Create a new ovsdb namespace
+        self.switches = []
+        name = 'ovsdb%d' % cls.ovsdbCount
+        kwargs.update( inNamespace=True )
+        kwargs.setdefault( 'privateDirs', self.privateDirs )
+        super( OVSDB, self ).__init__( name, **kwargs )
+        ovsdb = cnet.addHost( name, cls=self.self, **kwargs )
+        link = cnet.addLink( ovsdb, cnet.switches[ 0 ] )
+        cnet.switches[ 0 ].attach( link.intf2 )
+        ovsdb.configDefault()
+        ovsdb.startOVS()
+
+
+class OVSSwitchNS( OVSSwitch ):
+    "OVS Switch in shared OVSNS namespace"
+
+    isSetup = False
+
+    @classmethod
+    def batchStartup( cls, switches ):
+        result = []
+        for ovsdb, switchGroup in groupby( switches, attrgetter( 'ovsdb') ):
+            switchGroup = list( switchGroup )
+            info( '(%s)' % ovsdb )
+            result += OVSSwitch.batchStartup( switchGroup, run=ovsdb.cmd )
+        return result
+
+    @classmethod
+    def batchShutdown( cls, switches ):
+        result = []
+        for ovsdb, switchGroup in groupby( switches, attrgetter( 'ovsdb') ):
+            switchGroup = list( switchGroup )
+            info( '(%s)' % ovsdb )
+            result += OVSSwitch.batchShutdown( switchGroup, run=ovsdb.cmd )
+            for switch in switchGroup:
+                switch.ovsdbFree()
+        return result
+
+    # OVSDB allocation
+    groupSize = 1      # switch group size
+    switchCount = 0
+    lastOvsdb = None
+
+    @classmethod
+    def ovsdbAlloc( cls, switch ):
+        "Allocate (possibly new) OVSDB instance for switch"
+        if cls.switchCount % cls.groupSize == 0:
+            cls.lastOvsdb = OVSDB()
+        cls.switchCount += 1
+        cls.lastOvsdb.addSwitch( switch )
+        return cls.lastOvsdb
+
+    def ovsdbFree( self ):
+        "Deallocate OVSDB instance for switch"
+        self.ovsdb.delSwitch( self )
+
+    def startShell( self, *args, **kwargs ):
+        "Start shell in shared OVSDB namespace"
+        ovsdb = self.ovsdbAlloc( self )
+        kwargs.update( mnopts='-da %d ' % ovsdb.pid )
+        self.ns = [ 'net' ]
+        self.ovsdb = ovsdb
+        super( OVSSwitchNS, self ).startShell( *args, **kwargs )
+        self.defaultIntf().updateIP()
+
+    def start( self, controllers ):
+        "Update controller IP addresses if necessary"
+        for controller in controllers:
+            if controller.IP() == '127.0.0.1' and not controller.intfs:
+                controller.intfs[ 0 ] = self.ovsdb.rootIntf()
+        super( OVSSwitchNS, self ).start( controllers )
+
+    def stop( self, *args, **kwargs ):
+        "Stop and free OVSDB namespace if necessary"
+        super( OVSSwitchNS, self ).stop( *args, **kwargs )
+        self.ovsdbFree()
+
+    def defaultIntf( self ):
+        return self.ovsdb.defaultIntf()
+
+
+switches = { 'ovsns': OVSSwitchNS }
+
+
+def test():
+    "Test OVSNS switch"
+    setLogLevel( 'info' )
+    topo = TreeTopo( depth=4, fanout=2 )
+    net = Mininet( topo=topo, switch=OVSSwitchNS )
+    # Add connectivity to controller which is on LAN or in root NS
+    # net.addNAT().configDefault()
+    net.start()
+    CLI( net )
+    net.stop()
+
+
+if __name__ == '__main__':
+    test()

--- a/examples/multiovs.py
+++ b/examples/multiovs.py
@@ -28,7 +28,7 @@ class OVSDB( Node ):
                     '/var/log/openvswitch' ]
 
     # Control network
-    ipBase = '10.123.123.0/24'
+    ipBase = '172.123.123.0/24'
     cnet = None
     nat = None
 

--- a/examples/multiovs.py
+++ b/examples/multiovs.py
@@ -42,18 +42,12 @@ class OVSDB( Node ):
             cswitch = cnet.addSwitch( 'ovsbr0', cls=OVSBridge )
             # Add NAT - note this can conflict with data network NAT
             info( '### Adding NAT for control and data networks'
-                  '(do not use with --nat!)\n' )
+                  ' (use --nat flush=0 for data network)\n' )
             cls.cnet = cnet
-            cls.nat = cnet.addNAT()
+            cls.nat = cnet.addNAT( 'ovsdbnat0')
             cnet.start()
             info( '### Control network started\n' )
         return cnet
-
-    def attachNAT( self, switch ):
-        "Attach switch to NAT if necessary"
-        cls = self.__class__
-        if switch == self.switches[ 0 ]:
-            cls.cnet.addLink( cls.nat, switch )
     
     def stopControlNet( self ):
         info( '\n### Stopping control network\n' )
@@ -181,7 +175,6 @@ class OVSSwitchNS( OVSSwitch ):
         for controller in controllers:
             if controller.IP() == '127.0.0.1' and not controller.intfs:
                 controller.intfs[ 0 ] = self.ovsdb.nat.intfs[ 0 ]
-        self.ovsdb.attachNAT( self )
         super( OVSSwitchNS, self ).start( controllers )
 
     def stop( self, *args, **kwargs ):

--- a/examples/multiovs.py
+++ b/examples/multiovs.py
@@ -186,8 +186,8 @@ class OVSSwitchNS( OVSSwitch ):
         return self.ovsdb.defaultIntf()
 
     def __init__( self, *args, **kwargs ):
-        "group: number of OVS instances per OVSDB"
-        self.groupSize = kwargs.pop( 'group', self.groupSize )
+        "n: number of OVS instances per OVSDB"
+        self.groupSize = kwargs.pop( 'n', self.groupSize )
         super( OVSSwitchNS, self ).__init__( *args, **kwargs )
 
 

--- a/examples/multiovs.py
+++ b/examples/multiovs.py
@@ -20,6 +20,7 @@ from mininet.topo import LinearTopo, SingleSwitchTopo
 from mininet.topolib import TreeTopo
 from mininet.log import setLogLevel, info
 from mininet.cli import CLI
+from mininet.clean import Cleanup, sh
 
 from itertools import groupby
 from operator import attrgetter
@@ -99,6 +100,12 @@ class OVSDB( Node ):
         if self.__class__.ovsdbCount <= 0:
             self.stopControlNet()
 
+    @classmethod
+    def cleanup( cls ):
+        "Clean up leftover ovsdb-server/ovs-vswitchd processes"
+        info( '*** Shutting down extra ovsdb-server/ovs-vswitchd processes\n' )
+        sh( 'pkill -f mn.pid' )
+
     def self( self, *args, **kwargs ):
         "A fake constructor that sets params and returns self"
         self.params = kwargs
@@ -120,6 +127,8 @@ class OVSDB( Node ):
         ovsdb.configDefault()
         ovsdb.setDefaultRoute( 'via %s' % self.nat.intfs[ 0 ].IP() )
         ovsdb.startOVS()
+        # Install cleanup callback
+        Cleanup.addCleanupCallback( self.cleanup )
 
 
 class OVSSwitchNS( OVSSwitch ):

--- a/examples/multiovs.py
+++ b/examples/multiovs.py
@@ -79,21 +79,21 @@ class OVSDB( Node ):
                   ' -vfile:emer -vfile:err -vfile:info'
                   ' --remote=punix:/var/run/openvswitch/db.sock '
                   ' --log-file=/var/log/openvswitch/ovsdb-server.log'
-                  ' --pidfile=/var/run/openvswitch/ovsdb-server.pid'
+                  ' --pidfile=/var/run/openvswitch/ovsdb-server-mn.pid'
                   ' --no-chdir'
                   ' --detach' )
 
         self.cmd( 'ovs-vswitchd unix:/var/run/openvswitch/db.sock'
                   ' -vfile:emer -vfile:err -vfile:info'
                   ' --mlockall --log-file=/var/log/openvswitch/ovs-vswitchd.log'
-                  ' --pidfile=/var/run/openvswitch/ovs-vswitchd.pid'
+                  ' --pidfile=/var/run/openvswitch/ovs-vswitchd-mn.pid'
                   ' --no-chdir'
                   ' --detach' )
 
     def stopOVS( self ):
         self.cmd( 'kill',
-                  '`cat /var/run/openvswitch/ovs-vswitchd.pid`',
-                  '`cat /var/run/openvswitch/ovsdb-server.pid`' )
+                  '`cat /var/run/openvswitch/ovs-vswitchd-mn.pid`',
+                  '`cat /var/run/openvswitch/ovsdb-server-mn.pid`' )
         self.cmd( 'wait' )
         self.__class__.ovsdbCount -= 1
         if self.__class__.ovsdbCount <= 0:


### PR DESCRIPTION
ovsdb gets linearly slower as you add more switches to it.

A workaround is to run multiple ovsdb instances. This is exactly what we do:

- run multiple ovsdb instances
- run them in namespaces
- share the ovsdb namespaces among multiple OVS switches (`OVSSwitchNS`)

Running OVS in a namespace is somewhat complicated. For now we automatically attach
a NAT element so that they can connect to the root namespace as well as the LAN and beyond.
In the future we might want to revamp Mininet's `--innamespace` option to allow an explicit
control network, possibly with NAT.

Note that `--nat` can interfere with the control network NAT unless you specify `--nat flush=0`. In the future we may wish to make this the default.

Running multiple ovsdb instances, we can create 1024 (or more!) OVS switches relatively quickly, even on a laptop.
