### PR TITLE
Fixed `whoami` output problem in cluster.py

### DIFF
--- a/examples/cluster.py
+++ b/examples/cluster.py
@@ -103,7 +103,7 @@ def findUser():
             # Logged-in user (if we have a tty)
             ( quietRun( 'who am i' ).split() or [ False ] )[ 0 ] or
             # Give up and return effective user
-            quietRun( 'whoami' ) )
+            quietRun( 'whoami' ).strip() )
 
 
 class ClusterCleanup( object ):


### PR DESCRIPTION
Remove the last character when use `whoami`.