### PR TITLE
Fix ifconfig calls to allow setting IPv6 addresses on hosts

### DIFF
--- a/mininet/link.py
+++ b/mininet/link.py
@@ -73,13 +73,13 @@ class Intf( object ):
         # mechanism and/or the way we specify IP addresses
         if '/' in ipstr:
             self.ip, self.prefixLen = ipstr.split( '/' )
-            return self.ifconfig( ipstr, 'up' )
+            return self.ifconfig( 'add', ipstr, 'up' )
         else:
             if prefixLen is None:
                 raise Exception( 'No prefix length set for IP address %s'
                                  % ( ipstr, ) )
             self.ip, self.prefixLen = ipstr, prefixLen
-            return self.ifconfig( '%s/%s' % ( ipstr, prefixLen ) )
+            return self.ifconfig( 'add', '%s/%s' % ( ipstr, prefixLen ) )
 
     def setMAC( self, macstr ):
         """Set the MAC address for an interface.


### PR DESCRIPTION
It would probably be a good idea to consistantly use iproute instead of
ifconfig, but this is a simpler fix for now.