### PR TITLE
fix controller stdout output

### DIFF
--- a/mininet/node.py
+++ b/mininet/node.py
@@ -1389,7 +1389,7 @@ class Controller( Node ):
         if self.cdir is not None:
             self.cmd( 'cd ' + self.cdir )
         self.cmd( self.command + ' ' + self.cargs % self.port +
-                  ' 1>' + cout + ' 2>' + cout + ' &' )
+                  ' >' + cout + ' 2>&1 &' )
         self.execed = False
 
     def stop( self, *args, **kwargs ):


### PR DESCRIPTION
stdout was be truncated on bash

```
( echo "A"; echo "B" >&2 ) 1>out.txt 2>out.txt
```

Signed-off-by: Hiroaki KAWAI <hiroaki.kawai@gmail.com>