### PR TITLE
Fix documentation of failMode in OVSSwitch

### DIFF
--- a/mininet/node.py
+++ b/mininet/node.py
@@ -1028,7 +1028,7 @@ class OVSSwitch( Switch ):
                   inband=False, protocols=None,
                   reconnectms=1000, stp=False, batch=False, **params ):
         """name: name for switch
-           failMode: controller loss behavior (secure|open)
+           failMode: controller loss behavior (secure|standalone)
            datapath: userspace or kernel mode (kernel|user)
            inband: use in-band control (False)
            protocols: use specific OpenFlow version(s) (e.g. OpenFlow13)


### PR DESCRIPTION
According to the man page of ovs-vsctl, failure mode is either standalone or secure.  