### PR TITLE
TCIntf: Don't delete a non-existing root qdisc

### DIFF
--- a/mininet/link.py
+++ b/mininet/link.py
@@ -329,7 +329,7 @@ class TCIntf( Intf ):
 
         # Clear existing configuration
         tcoutput = self.tc( '%s qdisc show dev %s' )
-        if "priomap" not in tcoutput:
+        if "priomap" not in tcoutput and "noqueue" not in tcoutput:
             cmds = [ '%s qdisc del dev %s root' ]
         else:
             cmds = []


### PR DESCRIPTION
In recent kernels, virtual interfaces come without any associated
qdisc, resulting in errors when spawning the network.
Checking for "noqueue" in the tc output, enables to detect that
case and thus avoid deleting the non-existent qdisc.

Example:
When spawning the network:
```bash
added intf r4-eth2 (2) to node r4
moving r4-eth2 into namespace for r4
*** r4 : ('ifconfig', 'r4-eth2', 'up')
*** r4 : ('ethtool -K r4-eth2 gro off',)
 *** executing command: tc qdisc show dev r4-eth2
*** r4 : ('tc qdisc show dev r4-eth2',)
qdisc noqueue 0: root refcnt 2
(1.00Mbit) at map stage w/cmds: ['%s qdisc del dev %s root', '%s qdisc add dev %s root handle 5:0 htb default 1', '%s class add dev %s parent 5:0 classid 5:1 htb rate 1.000000Mbit burst 15k']
 *** executing command: tc qdisc del dev r4-eth2 root
*** r4 : ('tc qdisc del dev r4-eth2 root',)
RTNETLINK answers: No such file or directory
 *** executing command: tc qdisc add dev r4-eth2 root handle 5:0 htb default 1
*** r4 : ('tc qdisc add dev r4-eth2 root handle 5:0 htb default 1',)
 *** executing command: tc class add dev r4-eth2 parent 5:0 classid 5:1 htb rate 1.000000Mbit burst 15k
*** r4 : ('tc class add dev r4-eth2 parent 5:0 classid 5:1 htb rate 1.000000Mbit burst 15k',)
*** Error: RTNETLINK answers: No such file or directory
cmds: ['%s qdisc del dev %s root', '%s qdisc add dev %s root handle 5:0 htb default 1', '%s class add dev %s parent 5:0 classid 5:1 htb rate 1.000000Mbit burst 15k']
outputs: ['RTNETLINK answers: No such file or directory\r\n', '', '']
(c1, r4) *** d1 : ('ip link add name d1-eth0 address b6:dd:2a:98:50:ac type veth peer name r3-eth2 address 02:45:ec:8c:42:39 netns 2005',)
```
Note that the 2 RTNETLINK answers ... are the same, the first one being the output of stderr when running the command, the second one being the 'normal' minimal display of the error.