### PR TITLE
Script for diving into Mininet nodes

### DIFF
--- a/bin/mnenter
+++ b/bin/mnenter
@@ -1,0 +1,60 @@
+#!/bin/bash
+
+# Show usage
+usage()
+{
+    echo "Usage: $1 [options] NODE_NAME"
+    echo "(type mn -h for details)"
+    echo
+    echo "The mn utility opens Mininet node terminal from the command line."
+    echo
+    echo "Options:"
+    echo "  -h, --help            show this help message and exit"
+    echo
+}
+
+# Parse input args
+if [ $# -ne 1 ]
+then
+    usage
+    exit 0
+elif [ $1 = '-h' -o $1 = '--help' ]
+
+then
+    usage
+    exit 0
+fi
+
+TARGET_NODE=$1
+TARGET_RCFILE=/tmp/bashrc_${TARGET_NODE}
+TARGET_NSLINK=/var/run/netns/${TARGET_NODE}
+TARGET_PID=`pgrep -f "mininet:${TARGET_NODE}"`
+if [ ! ${TARGET_PID} ]
+then
+    echo "No such node name: ${TARGET_NODE}"
+    exit 1
+fi
+
+# Make a link file to the target namespace
+if [ ! -d /var/run/netns ]
+then
+    sudo mkdir -p /var/run/netns
+fi
+if [ ! -L ${TARGET_NSLINK} ]
+then
+    sudo ln -s /proc/${TARGET_PID}/ns/net ${TARGET_NSLINK}
+fi
+
+# Invoke bash with the rcfile
+sudo echo "PS1=${TARGET_NODE}'> '" > ${TARGET_RCFILE}
+sudo ip netns exec ${TARGET_NODE} bash --rcfile ${TARGET_RCFILE}
+
+# Clean up
+if [ -L ${TARGET_NSLINK} ]
+then
+    sudo rm ${TARGET_NSLINK}
+fi
+if [ -f ${TARGET_RCFILE} ]
+then
+    sudo rm ${TARGET_RCFILE}
+fi

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ import sys
 sys.path.append( '.' )
 from mininet.net import VERSION
 
-scripts = [ join( 'bin', filename ) for filename in [ 'mn' ] ]
+scripts = [ join( 'bin', filename ) for filename in [ 'mn', 'mnenter' ] ]
 
 modname = distname = 'mininet'
 


### PR DESCRIPTION
If you are using Mininet on a remote host, you may need to setup
X11 forwarding, but it can be bothersome.
Sometime, you cannot open display, need to install cygwin on Windows,
may forget "-X" or "-Y" options and so on.

This patch provides a script in order to open bash in the specified
Mininet node and makes you free from the above problems.

Usage example: Open bash in "h1"
  $ sudo mnenter h1
  h1> ip link
  1: lo: <LOOPBACK,UP,LOWER_UP> mtu 65536 qdisc noqueue state UNKNOWN mode DEFAULT group default
      link/loopback 00:00:00:00:00:00 brd 00:00:00:00:00:00
  2: h1-eth0: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc pfifo_fast state UP mode DEFAULT group default qlen 1000
      link/ether 92:1a:76:a8:b6:5a brd ff:ff:ff:ff:ff:ff

Signed-off-by: IWASE Yusuke <iwase.yusuke0@gmail.com>