### PR TITLE
link: Fix circular import

### DIFF
--- a/mininet/link.py
+++ b/mininet/link.py
@@ -26,7 +26,6 @@ Link: basic link class for creating veth pairs
 
 from mininet.log import info, error, debug
 from mininet.util import makeIntfPair
-import mininet.node
 import re
 
 class Intf( object ):
@@ -504,10 +503,12 @@ class OVSLink( Link ):
        than ~64 OVS patch links should be used in row."""
 
     def __init__( self, node1, node2, **kwargs ):
+        from mininet.node import OVSSwitch
+
         "See Link.__init__() for options"
         self.isPatchLink = False
-        if ( isinstance( node1, mininet.node.OVSSwitch ) and
-             isinstance( node2, mininet.node.OVSSwitch ) ):
+        if ( isinstance( node1, OVSSwitch ) and
+             isinstance( node2, OVSSwitch ) ):
             self.isPatchLink = True
             kwargs.update( cls1=OVSIntf, cls2=OVSIntf )
         Link.__init__( self, node1, node2, **kwargs )


### PR DESCRIPTION
Having an 'import mininet.node' in the link module causes
a circular import as the node module also has a top-level
import for the link module.

In order to break the cycle, the import for the node module
is delayed and executed only if using the sole class that
actually needs it in the link module.

The trace below shows a first attempt at importing the module failing,
then the current workaround by using the fact that imports are cached, thus by
importing first the node module then the link one -- although the only
import we wanted in the first place was the link one, so we actually polluted
our namespace.

``` python
Python 2.7.11 (default, Mar  3 2016, 11:00:04) 
[GCC 5.3.0] on linux2
Type "help", "copyright", "credits" or "license" for more information.
>>> import mininet.link
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/usr/lib/python2.7/site-packages/mininet/link.py", line 29, in <module>
    import mininet.node
  File "/usr/lib/python2.7/site-packages/mininet/node.py", line 67, in <module>
    from mininet.link import Link, Intf, TCIntf, OVSIntf
ImportError: cannot import name Link
>>> import mininet.node
>>> import mininet.link
>>> 

```
