### PR TITLE
mininet: node: Fallback to ovs-testcontroller

### DIFF
--- a/mininet/node.py
+++ b/mininet/node.py
@@ -1426,6 +1426,8 @@ class OVSController( Controller ):
     def __init__( self, name, command='ovs-controller', **kwargs ):
         if quietRun( 'which test-controller' ):
             command = 'test-controller'
+        if quietRun( 'which ovs-testcontroller' ):
+            command = 'ovs-testcontroller'
         Controller.__init__( self, name, command=command, **kwargs )
 
     @classmethod


### PR DESCRIPTION
Commit db3bffa971a8("Check for ovs-testcontroller in OVSController")
only added partial support for the renamed ovs controller. We also need
to use it as the default controller if 'ovs-controller' and
'test-controller' do not exist.
