### PR TITLE
Overlay directories + Change the hostnames of nodes

### DIFF
--- a/mininet/node.py
+++ b/mininet/node.py
@@ -174,6 +174,12 @@ class Node( object ):
         "mount overlay directories"
         # Avoid expanding a string into a list of chars
         assert not isinstance( self.overlayDirs, basestring )
+        if self.overlayDirs:
+            with open('/proc/filesystems', 'r') as f:
+                if 'overlay' not in f.read():
+                    raise OSError('OverlayFS is not supported by your kernel but is required by node %s' %
+                                    self.name)
+
         for directory in self.overlayDirs:
             if isinstance( directory, tuple ):
                 # mount given overlay directory

--- a/mininet/node.py
+++ b/mininet/node.py
@@ -130,11 +130,12 @@ class Node( object ):
         # (p)rint pid, and run in (n)amespace
         opts = '-cd' if mnopts is None else mnopts
         if self.inNamespace:
+            opts = '-H %s %s' % (self.name, opts)
             opts += 'n'
         # bash -i: force interactive
         # -s: pass $* to shell, and make process easy to find in ps
         # prompt is set to sentinel chr( 127 )
-        cmd = [ 'mnexec', opts, 'env', 'PS1=' + chr( 127 ),
+        cmd = [ 'mnexec' ] + opts.split() + [ 'env', 'PS1=' + chr( 127 ),
                 'bash', '--norc', '-is', 'mininet:' + self.name ]
         # Spawn a shell subprocess in a pseudo-tty, to disable buffering
         # in the subprocess and insulate it from signals (e.g. SIGINT)

--- a/mininet/node.py
+++ b/mininet/node.py
@@ -196,7 +196,7 @@ class Node( object ):
                 self.cmd( 'mkdir -p %s', overlayDir )
 
             workDir = overlayDir + '.work'
-            self.cmd( 'mkdir -p %s %s' % (mountPoint, workDir) )
+            self.cmd( 'mkdir -p %s %s %s' % (mountPoint, workDir, overlayDir) )
             self.cmd( 'mount -t overlay overlay -o lowerdir=%s,upperdir=%s,workdir=%s %s' %
                         ( mountPoint, overlayDir, workDir, mountPoint ) )
 

--- a/mininet/node.py
+++ b/mininet/node.py
@@ -199,12 +199,15 @@ class Node( object ):
         for directory in self.overlayDirs:
             if isinstance( directory, tuple ):
                 mountPoint = directory[ 0 ]
+                overlayDir = directory[ 1 ] % self.__dict__
+                workDir = overlayDir + '.work'
                 self.cmd( 'umount ', mountPoint )
+                self.cmd( 'rmdir %s/work %s' % (workDir, workDir) )
             else:
                 mountPoint = directory
                 self.cmd( 'umount ', mountPoint )
-                tmpDir = '/tmp/mininet/%s/%s' % (self, directory)
-                self.cmd( 'umount ', tmpDir )
+                self.cmd( 'umount ', '/tmp/mininet/%s/%s' % (self, directory) )
+                self.cmd( 'rmdir /tmp/mininet/%s%s /tmp/mininet/%s /tmp/mininet' % (self, directory, self) )
 
     def mountPrivateDirs( self ):
         "mount private directories"

--- a/mininet/term.py
+++ b/mininet/term.py
@@ -54,7 +54,7 @@ def makeTerm( node, title='Node', term='xterm', display=None, cmd='bash'):
     display, tunnel = tunnelX11( node, display )
     if display is None:
         return []
-    term = node.popen( cmds[ term ] +
+    term = node.popen( [ '-H', node.name ] + cmds[ term ] +
                        [ display, '-e', 'env TERM=ansi %s' % cmd ] )
     return [ tunnel, term ] if tunnel else [ term ]
 

--- a/mininet/term.py
+++ b/mininet/term.py
@@ -7,6 +7,7 @@ Optionally uses gnome-terminal.
 """
 
 from os import environ
+import subprocess
 
 from mininet.log import error
 from mininet.util import quietRun, errRun
@@ -28,6 +29,11 @@ def tunnelX11( node, display=None):
         quietRun( 'xhost +si:localuser:root' )
         return display, None
     else:
+        # Add credentials with new hostname
+        creds = subprocess.check_output( 'xauth list $DISPLAY', shell=True )
+        newCred = node.name + '/' + creds.split('/', 1)[ 1 ]
+        node.cmd( 'xauth add ' + newCred )
+
         # Create a tunnel for the TCP connection
         port = 6000 + int( float( screen ) )
         connection = r'TCP\:%s\:%s' % ( host, port )

--- a/mnexec.c
+++ b/mnexec.c
@@ -24,6 +24,8 @@
 #include <sched.h>
 #include <ctype.h>
 #include <sys/mount.h>
+#include <sys/param.h>
+#include <string.h>
 
 #if !defined(VERSION)
 #define VERSION "(devel)"
@@ -102,8 +104,22 @@ int main(int argc, char *argv[])
     char *cwd = get_current_dir_name();
 
     static struct sched_param sp;
-    while ((c = getopt(argc, argv, "+cdnpa:g:r:vh")) != -1)
+    while ((c = getopt(argc, argv, "+H:cdnpa:g:r:vh")) != -1)
         switch(c) {
+        case 'H':
+            /* rename if we have a hostname */
+            if (*optarg) {
+                if (unshare(CLONE_NEWUTS) == -1) {
+                    perror("unshare");
+                    return 1;
+                }
+
+                if (sethostname(optarg, MIN(strlen(optarg), HOST_NAME_MAX)) == -1) {
+                    perror("sethostname");
+                    return 1;
+                }
+            }
+            break;
         case 'c':
             /* close file descriptors except stdin/out/error */
             for (fd = getdtablesize(); fd > 2; fd--)


### PR DESCRIPTION
- Adds support for OverlayFS type directories, same syntax as PrivateDirs
- Changes the hostname in the different nodes, i.e. `mininet> h1 hostname` returns `h1` and when you do `xterm h1` you get a prompt like `root@h1:~#`
- Because of this some tweaking is needed for X11 authentication to work (add the current MIT cookie with the new hostname)

Some programs expect hostnames to be unique hence this feature.



