### PR TITLE
add cleanup of mn

### DIFF
--- a/mininet/clean.py
+++ b/mininet/clean.py
@@ -61,7 +61,10 @@ class Cleanup( object ):
         sh( 'killall -9 ' + zombies + ' 2> /dev/null' )
 
         # And kill off sudo mnexec
-        sh( 'pkill -9 -f "sudo mnexec"')
+        sh( 'pkill -9 -f "sudo mnexec"' )
+
+        # And kill off mn, mn doesn't exit when start twice "mn".
+        sh( 'pkill -9 -f "mn"' )
 
         info( "*** Removing junk from /tmp\n" )
         sh( 'rm -f /tmp/vconn* /tmp/vlogs* /tmp/*.out /tmp/*.log' )


### PR DESCRIPTION
When start twice “mn”， as the port 6633 is taken by the first mn,
the second run will raise Exception, and triggers the cleanup method
defined in mininet/cleanup.py, but the cleanup doesn't cleanup the
"/usr/bin/env python /usr/local/bin/mn" process, which is added in this commit.
