### PR TITLE
link: Set prefixLen for loopback address

### DIFF
--- a/mininet/link.py
+++ b/mininet/link.py
@@ -49,6 +49,7 @@ class Intf( object ):
         # This saves an ifconfig command per node
         if self.name == 'lo':
             self.ip = '127.0.0.1'
+            self.prefixLen = 8
         # Add to node (and move ourselves if necessary )
         moveIntfFn = params.pop( 'moveIntfFn', None )
         if moveIntfFn:


### PR DESCRIPTION
The prefixLen for a loopback address is well-defined (/32),
and as such the variable is set accordingly.

Previously, loopback interfaces kept prefixLen set to None, 
which was troublesome.