### PR TITLE
Create TCLink1 for asymmetric TCLink properties

### DIFF
--- a/bin/mn
+++ b/bin/mn
@@ -30,7 +30,7 @@ from mininet.node import ( Host, CPULimitedHost, Controller, OVSController,
                            UserSwitch, OVSSwitch, OVSBridge,
                            IVSSwitch )
 from mininet.nodelib import LinuxBridge
-from mininet.link import Link, TCLink, OVSLink
+from mininet.link import Link, TCLink, TCLink1, OVSLink
 from mininet.topo import ( SingleSwitchTopo, LinearTopo,
                            SingleSwitchReversedTopo, MinimalTopo )
 from mininet.topolib import TreeTopo, TorusTopo
@@ -85,6 +85,7 @@ CONTROLLERS = { 'ref': Controller,
 LINKDEF = 'default'
 LINKS = { 'default': Link,
           'tc': TCLink,
+          'tc1': TCLink1,
           'ovs': OVSLink }
 
 

--- a/mininet/link.py
+++ b/mininet/link.py
@@ -533,10 +533,12 @@ class TCLink( Link ):
                        addr1=addr1, addr2=addr2,
                        params1=params,
                        params2=params )
+
 class TCLink1( Link ):
      "Link with potential asymetric TC interfaces configured via opts"
-     def __init__( self,node1,node2,port1=None,port2=None,
-                   intfName1=None, intfName2, **params):
+     def __init__( self, node1, node2, port1=None, port2=None,
+                   intfName1=None, intfName2=None,
+                   addr1=None, addr2=None, **params):
          if isinstance(params,dict):
              pars1 = {}
              pars2 = {}
@@ -551,5 +553,6 @@ class TCLink1( Link ):
                        intfName1=intfName1, intfName2=intfName2,
                        cls1=TCIntf,
                        cls2=TCIntf,
+                       addr1=addr1, addr2=addr2,
                        params1=pars1,
                        params2=pars2)

--- a/mininet/link.py
+++ b/mininet/link.py
@@ -533,3 +533,23 @@ class TCLink( Link ):
                        addr1=addr1, addr2=addr2,
                        params1=params,
                        params2=params )
+class TCLink1( Link ):
+     "Link with potential asymetric TC interfaces configured via opts"
+     def __init__( self,node1,node2,port1=None,port2=None,
+                   intfName1=None, intfName2, **params):
+         if isinstance(params,dict):
+             pars1 = {}
+             pars2 = {}
+             if 'params1' in params:
+                 pars1 = params['params1']
+             if 'params2' in params:
+                 pars2 = params['params2']
+         else:
+             print 'Dictionnary expected for asymetric link pars'
+
+         Link.__init__(self, node1, node2, port1=port1, port2=port2,
+                       intfName1=intfName1, intfName2=intfName2,
+                       cls1=TCIntf,
+                       cls2=TCIntf,
+                       params1=pars1,
+                       params2=pars2)

--- a/mininet/link.py
+++ b/mininet/link.py
@@ -535,19 +535,24 @@ class TCLink( Link ):
                        params2=params )
 
 class TCLink1( Link ):
-     "Link with potential asymetric TC interfaces configured via opts"
+     "Link with potential asymmetric TC interfaces configured via opts"
      def __init__( self, node1, node2, port1=None, port2=None,
                    intfName1=None, intfName2=None,
                    addr1=None, addr2=None, **params):
-         if isinstance(params,dict):
-             pars1 = {}
-             pars2 = {}
-             if 'params1' in params:
-                 pars1 = params['params1']
-             if 'params2' in params:
-                 pars2 = params['params2']
-         else:
-             print 'Dictionnary expected for asymetric link pars'
+         p1 = {}
+         p2 = {}
+         if 'params1' in params:
+             p1 = params['params1']
+             del params['params1']
+         if 'params2' in params:
+             p2 = params['params2']
+             del params['params2']
+
+         pars1 = params.copy()
+         pars1.update(p1)
+
+         pars2 = params.copy()
+         pars2.update(p2)
 
          Link.__init__(self, node1, node2, port1=port1, port2=port2,
                        intfName1=intfName1, intfName2=intfName2,


### PR DESCRIPTION
Since TCLink supports only symmetric linkopts currently, if only one side of the link needs to get some properties, the result would be incorrect. I have encountered a problem when I tried to assign 'ip' to one side of the link, but by using TCLink I cannot get the hosts connected. 