### PR TITLE
Use hex encoding of node name to compute dpid

### DIFF
--- a/mininet/node.py
+++ b/mininet/node.py
@@ -867,21 +867,25 @@ class Switch( Node ):
             self.controlIntf = Intf( 'lo', self, port=0 )
 
     def defaultDpid( self, dpid=None ):
-        "Return correctly formatted dpid from dpid or switch name (s1 -> 1)"
-        if dpid:
-            # Remove any colons and make sure it's a good hex number
-            dpid = dpid.translate( None, ':' )
-            assert len( dpid ) <= self.dpidLen and int( dpid, 16 ) >= 0
-        else:
-            # Use hex encoding of node name, limited to 16 characters as dpid
-            if self.name is not None and self.name != "":
-                dpid = self.name.encode("hex")[:self.dpidLen]
-                return '0' * ( self.dpidLen - len( dpid ) ) + dpid
+            "Return correctly formatted dpid from dpid or switch name (s1 -> 1)"
+            if dpid:
+                # Remove any colons and make sure it's a good hex number
+                dpid = dpid.translate( None, ':' )
+                assert len( dpid ) <= self.dpidLen and int( dpid, 16 ) >= 0
             else:
-                raise Exception( 'Unable to derive default datapath ID - '
-                                 'please either specify a dpid or use a '
-                                 'canonical switch name such as s23. '
-                                 'The name '+self.name+" seems to be empty or invalid." )
+                # Use hex of the first number in the switch name
+                nums = re.findall( r'\d+', self.name )
+                if nums:
+                    dpid = hex( int( nums[ 0 ] ) )[ 2: ]
+                elif self.name is not None and self.name != "":
+                    # Use hex encoding of node name, limited to 16 characters as dpid, 
+                    # if switchname does not contain a number
+                    dpid = self.name.encode("hex")[:self.dpidLen]
+                else:
+                    raise Exception( 'Unable to derive default datapath ID - '
+                                     'please either specify a dpid or use a '
+                                     'canonical switch name such as s23.' )
+                return '0' * ( self.dpidLen - len( dpid ) ) + dpid
 
     def defaultIntf( self ):
         "Return control interface"

--- a/mininet/node.py
+++ b/mininet/node.py
@@ -873,15 +873,15 @@ class Switch( Node ):
             dpid = dpid.translate( None, ':' )
             assert len( dpid ) <= self.dpidLen and int( dpid, 16 ) >= 0
         else:
-            # Use hex of the first number in the switch name
-            nums = re.findall( r'\d+', self.name )
-            if nums:
-                dpid = hex( int( nums[ 0 ] ) )[ 2: ]
+            # Use hex encoding of node name, limited to 16 characters as dpid
+            if self.name is not None and self.name != "":
+                dpid = self.name.encode("hex")[:self.dpidLen]
+                return '0' * ( self.dpidLen - len( dpid ) ) + dpid
             else:
                 raise Exception( 'Unable to derive default datapath ID - '
                                  'please either specify a dpid or use a '
-                                 'canonical switch name such as s23.' )
-        return '0' * ( self.dpidLen - len( dpid ) ) + dpid
+                                 'canonical switch name such as s23. '
+                                 'The name '+self.name+" seems to be empty or invalid." )
 
     def defaultIntf( self ):
         "Return control interface"


### PR DESCRIPTION
The computation of a default dpid should not rely on the node name having a number in it. This may not be true for all names and will irritate everyone new to Mininet (like me).
PS: I hope I picked the correct branch for this pull request.