### PR TITLE
Node: support setHostname to run a node in its own UTS namespace

### DIFF
--- a/mininet/topolib.py
+++ b/mininet/topolib.py
@@ -34,6 +34,7 @@ class TreeTopo( Topo ):
 
 def TreeNet( depth=1, fanout=2, **kwargs ):
     "Convenience function for creating tree networks."
+    # topo = TreeTopo( depth, fanout, hopts={'setHostname':True})
     topo = TreeTopo( depth, fanout )
     return Mininet( topo, **kwargs )
 


### PR DESCRIPTION
This is important for applications that rely on having hostnames within the same network.

Using this feature still requires manual editing for `/etc/hosts` — perhaps there is a popular tool that fakes a DNS server for such purposes? Not sure if it would be ok to edit the system config file at will (which may be fine in case of the VM).

Submitting this for early feedback.

Refs #484 