### PR TITLE
Add vpp as a possible switch

### DIFF
--- a/bin/mn
+++ b/bin/mn
@@ -27,7 +27,7 @@ from mininet.net import Mininet, MininetWithControlNet, VERSION
 from mininet.node import ( Host, CPULimitedHost, Controller, OVSController,
                            Ryu, NOX, RemoteController, findController,
                            DefaultController, NullController,
-                           UserSwitch, OVSSwitch, OVSBridge,
+                           UserSwitch, OVSSwitch, OVSBridge, VPPSwitch,
                            IVSSwitch )
 from mininet.nodelib import LinuxBridge
 from mininet.link import Link, TCLink, TCULink, OVSLink
@@ -65,6 +65,7 @@ SWITCHES = { 'user': UserSwitch,
              'ovsk': OVSSwitch,
              'ivs': IVSSwitch,
              'lxbr': LinuxBridge,
+             'vpp': VPPSwitch,
              'default': OVSSwitch }
 
 HOSTDEF = 'proc'


### PR DESCRIPTION
The integration is done using the python API, and presenting the vpp cli
to mininet via dpctl.

vpp import is left within the VPPSwitch class so that this does not
become a new dependency.
