### PR TITLE
bin/mn: log version() on OUTPUT level

### DIFF
--- a/bin/mn
+++ b/bin/mn
@@ -22,7 +22,7 @@ if 'PYTHONPATH' in os.environ:
 
 from mininet.clean import cleanup
 from mininet.cli import CLI as CLI
-from mininet.log import lg, LEVELS, info, debug, warn, error
+from mininet.log import lg, LEVELS, info, output, debug, warn, error
 from mininet.net import Mininet, MininetWithControlNet, VERSION
 from mininet.node import ( Host, CPULimitedHost, Controller, OVSController,
                            Ryu, NOX, RemoteController, findController,
@@ -149,7 +149,7 @@ def addDictOption( opts, choicesDict, default, name, **kwargs ):
 
 def version( *_args ):
     "Print Mininet version and exit"
-    info( "%s\n" % VERSION )
+    output( "%s\n" % VERSION )
     exit()
 
 


### PR DESCRIPTION
For reasons discussed in issue #661, we change the log level to `OUTPUT` for `bin/mn --version`.