### PR TITLE
Changes override method from __init__ to build

### DIFF
--- a/examples/simpleperf.py
+++ b/examples/simpleperf.py
@@ -21,8 +21,7 @@ from sys import argv
 
 class SingleSwitchTopo(Topo):
     "Single switch connected to n hosts."
-    def __init__(self, n=2, lossy=True, **opts):
-        Topo.__init__(self, **opts)
+    def build(self, n=2,lossy=True, **opts):
         switch = self.addSwitch('s1')
         for h in range(n):
             # Each host gets 50%/n of system CPU


### PR DESCRIPTION
With reference to the write up below which is available on [Introduction to mininet](https://github.com/mininet/mininet/wiki/Introduction-to-Mininet), I think we should update the older example. 

> Note for earlier Mininet Versions The topology API has changed slightly across different versions of Mininet. In 1.0, methods such as addSwitch and addHost were called add_switch and add_host. Additionally, in both 1.0 and 2.0, the preferred method to override was __init__ rather than build:
> 
>     class SingleSwitchTopo(Topo):
>         "Single switch connected to n hosts."
>         def __init__(self, n=2, **opts):
>             # Initialize topology and default options
>             Topo.__init__(self, **opts)
>             switch = self.addSwitch('s1')
>             # Python's range(N) generates 0..N-1
>             for h in range(n):
>                 host = self.addHost('h%s' % (h + 1))
>                 self.addLink(host, switch)