### PR TITLE
Fix for adding multiple controllers and swtiches

### DIFF
--- a/mininet/net.py
+++ b/mininet/net.py
@@ -532,7 +532,7 @@ class Mininet( object ):
                 if src != dst:
                     src.setARP( ip=dst.IP(), mac=dst.MAC() )
 
-    def start( self ):
+    def start( self , switchControllerMap={}):
         "Start controller and switches."
         if not self.built:
             self.build()
@@ -541,10 +541,20 @@ class Mininet( object ):
             info( controller.name + ' ')
             controller.start()
         info( '\n' )
+        if switchControllerMap:
+            info( 'Custom Switch Controller map is provided and being used' )
+            self.switchControllerMap=switchControllerMap
         info( '*** Starting %s switches\n' % len( self.switches ) )
         for switch in self.switches:
             info( switch.name + ' ')
-            switch.start( self.controllers )
+            if switchControllerMap:
+                if type( switchControllerMap[switch.name] ) is list:
+                    controllers = switchControllerMap[switch.name]
+                else:
+                    controllers = [switchControllerMap[switch.name]]
+            else:
+                controllers=self.controllers
+            switch.start( controllers )
         started = {}
         for swclass, switches in groupby(
                 sorted( self.switches, key=type ), type ):


### PR DESCRIPTION
For adding multiple controllers and switches with custom mapping, the implementation suggested in the examples is not  straight forward. The implementation here is mapping the swithes to controllers in start.