### PR TITLE
Fix regex for ping result parsing

### DIFF
--- a/mininet/net.py
+++ b/mininet/net.py
@@ -632,7 +632,7 @@ class Mininet( object ):
         # Check for downed link
         if 'connect: Network is unreachable' in pingOutput:
             return 1, 0
-        r = r'(\d+) packets transmitted, (\d+) received'
+        r = r'(\d+) packets transmitted, (\d+)( packets)? received'
         m = re.search( r, pingOutput )
         if m is None:
             error( '*** Error: could not parse ping output: %s\n' %


### PR DESCRIPTION
I tried to run the pingall test on my host but it always failed. I discovered that the output of the `ping` programm changed and that therefore the parsing failed. This is a small fix to correctly parse the new output format. It should be backwards compatible.