### PR TITLE
Changed verifying the OVS version to not require root in MiniEdit.

### DIFF
--- a/examples/miniedit.py
+++ b/examples/miniedit.py
@@ -379,8 +379,8 @@ class PrefsDialog(tkSimpleDialog.Dialog):
     @staticmethod
     def getOvsVersion():
         "Return OVS version"
-        outp = quietRun("ovs-vsctl show")
-        r = r'ovs_version: "(.*)"'
+        outp = quietRun("ovs-vsctl --version")
+        r = r'ovs-vsctl \(Open vSwitch\) (.*)'
         m = re.search(r, outp)
         if m is None:
             warn( 'Version check failed' )


### PR DESCRIPTION
Verifying the OVS version required root since it ran `ovs-vsctl show`. Although needing root makes sense when trying to run the topology, the OVS version is also confirmed while changing topology preferences which may be done locally without having root access. This small change makes changing the OpenFlow protocol preferences non-root accessible.