### PR TITLE
Updating Mininet to start with host IP request in ipBase

### DIFF
--- a/mininet/net.py
+++ b/mininet/net.py
@@ -144,7 +144,8 @@ class Mininet( object ):
         self.intf = intf
         self.ipBase = ipBase
         self.ipBaseNum, self.prefixLen = netParse( self.ipBase )
-        self.nextIP = 1  # start for address allocation
+        hostIP = ( 0xffffffff >> self.prefixLen ) & self.ipBaseNum
+        self.nextIP = hostIP if hostIP > 0 else 1  # start for address allocation
         self.inNamespace = inNamespace
         self.xterms = xterms
         self.cleanup = cleanup

--- a/mininet/util.py
+++ b/mininet/util.py
@@ -321,7 +321,7 @@ def ipParse( ip ):
     "Parse an IP address and return an unsigned int."
     args = [ int( arg ) for arg in ip.split( '.' ) ]
     while len(args) < 4:
-        args.append( 0 )
+        args.insert( len(args) - 1, 0 )
     return ipNum( *args )
 
 def netParse( ipstr ):


### PR DESCRIPTION
Instead of always starting with the first host IP in a subnet, this pull request starts at either the first host IP or the host IP specified in the ipbase argument, whichever is greater.

Note: This change also slightly modifies how the ipbase is interpreted:
10.2/8 was previously interpreted as 10.2.0.0/8
10.2/8 would now be interpreted as 10.0.0.2/8 (which is more in line with Linux utilities)

Also, users who specified an ipbase with a random host IP will experience different IP addresses assigned to their hosts.