### PR TITLE
Fixed client/server order according to docs

### DIFF
--- a/mininet/net.py
+++ b/mininet/net.py
@@ -803,7 +803,7 @@ class Mininet( object ):
            rate should be much closer to the actual receive rate"""
         hosts = hosts or [ self.hosts[ 0 ], self.hosts[ -1 ] ]
         assert len( hosts ) == 2
-        client, server = hosts
+        server, client = hosts
         output( '*** Iperf: testing', l4Type, 'bandwidth between',
                 client, 'and', server, '\n' )
         server.cmd( 'killall -9 iperf' )


### PR DESCRIPTION
For iperf, the documentation in the function points to supplying hosts input as [server, client]
but the code interprets it in the reverse order. Fixed this issue.