### PR TITLE
Modify the default latency type from int to float if tbf is enabled.

### DIFF
--- a/mininet/link.py
+++ b/mininet/link.py
@@ -252,7 +252,7 @@ class TCIntf( Intf ):
                           + 'rate %fMbit ul rate %fMbit' % ( bw, bw ) ]
             elif use_tbf:
                 if latency_ms is None:
-                    latency_ms = 15 * 8 / bw
+                    latency_ms = 15.0 * 8 / bw
                 cmds += [ '%s qdisc add dev %s root handle 5: tbf ' +
                           'rate %fMbit burst 15000 latency %fms' %
                           ( bw, latency_ms ) ]


### PR DESCRIPTION
- For issue #729 
- the original version will caluse the latency to 0 when bandwidth
  is bigger than 200;
- the TC command doesn't allow use the 0.00ms as input for latency field

Signed-off-by: hwchiu <sppsorrg@gmail.com>