### PR TITLE
Add ability to overwrite `mncmd`

### DIFF
--- a/mininet/node.py
+++ b/mininet/node.py
@@ -702,8 +702,11 @@ class CPULimitedHost( Host ):
            args: Popen() args, single list, or string
            kwargs: Popen() keyword args"""
         # Tell mnexec to execute command in our cgroup
-        mncmd = [ 'mnexec', '-g', self.name,
-                  '-da', str( self.pid ) ]
+        if 'mncmd' in kwargs:
+            mncmd = kwargs['mncmd']
+        else:
+            mncmd = [ 'mnexec', '-g', self.name,
+                      '-da', str( self.pid ) ]
         # if our cgroup is not given any cpu time,
         # we cannot assign the RR Scheduler.
         if self.sched == 'rt':


### PR DESCRIPTION
In `Host.popen`, user could provide `mncmd` in `kwargs` and it will overwrite the default `mncmd` command options. But in `CPULimitedHost.popen` providing `mncmd` will result in duplicate keywords error.

I'm proposing this fix so user could overwrite `mncmd` when using `CPULimitedHost.popen`.

It is extremely useful sometimes. For example, by default `mncmd` creates a new session ID for each underlying process. If the user provides `shell=True` when using `popen`, the underlying process will be really hard to kill. Because its PID is not returned (its parent's PID is returned), and it does not belong to any know group. In this case (when running `popen` with `shell=True`), I would like to disable `-d` option in `mncmd` but now I'm not able to do that.