### PR TITLE
Fix the pylint warning

### DIFF
--- a/bin/mn
+++ b/bin/mn
@@ -94,6 +94,8 @@ TESTS = { name: True
           for name in ( 'pingall', 'pingpair', 'iperf', 'iperfudp' ) }
 
 
+CLI = None
+
 # Locally defined tests
 def allTest( net ):
     "Run ping and iperf tests"
@@ -314,6 +316,7 @@ class MininetRunner( object ):
     def begin( self ):
         "Create and run mininet."
 
+        # pylint: disable=global-statement
         global CLI
 
         opts = self.options
@@ -388,7 +391,8 @@ class MininetRunner( object ):
             mn.addNAT( *opts.nat_args, **opts.nat_kwargs ).configDefault()
 
         # --custom files can set CLI or change mininet.cli.CLI
-        globals().setdefault( 'CLI', mininet.cli.CLI )
+        if CLI is None:
+            CLI = mininet.cli.CLI
 
         if opts.pre:
             CLI( mn, script=opts.pre )


### PR DESCRIPTION
- Ignore `global statement` warning of pylint.
- Use the variable CLI instead of global's dictionary, otherwise pylink can't reconginize the vairable