### PR TITLE
Script install.sh is changed with some corrections for user mininet

### DIFF
--- a/util/install.sh
+++ b/util/install.sh
@@ -205,7 +205,7 @@ function of13 {
     echo "Installing OpenFlow 1.3 soft switch implementation..."
     cd $BUILD_DIR/
     $install  git-core autoconf automake autotools-dev pkg-config \
-        make gcc g++ libtool libc6-dev cmake libpcap-dev libxerces-c2-dev  \
+        make gcc g++ libtool libc6-dev cmake libpcap-dev libxerces-c3-dev  \
         unzip libpcre3-dev flex bison libboost-dev
 
     if [ ! -d "ofsoftswitch13" ]; then
@@ -218,17 +218,10 @@ function of13 {
     fi
 
     # Install netbee
-    if [ "$DIST" = "Ubuntu" ] && version_ge $RELEASE 14.04; then
-        NBEESRC="nbeesrc-feb-24-2015"
-        NBEEDIR="netbee"
-    else
-        NBEESRC="nbeesrc-jan-10-2013"
-        NBEEDIR="nbeesrc-jan-10-2013"
-    fi
+    NBEESRC="https://github.com/netgroup-polito/netbee.git"
+    NBEEDIR="netbee"
 
-    NBEEURL=${NBEEURL:-http://www.nbee.org/download/}
-    wget -nc ${NBEEURL}${NBEESRC}.zip
-    unzip ${NBEESRC}.zip
+    git clone ${NBEESRC} ${NBEEDIR}
     cd ${NBEEDIR}/src
     cmake .
     make


### PR DESCRIPTION
There were some exceptions while installing user mininet (ofsoftswitch) with command "./install.sh -n3fxw".
Therefore install.sh script has corrected with some changes.
The libxerces-c2-dev library have been upgraded to libxerces-c3-dev.
Unreachable nbee website has been replaced with git url. Now nbee library is able to be downloaded from github.
