### PR TITLE
Remove '- dist: xenial'. Both jobs are run in the same Ubuntu version as shown in the build logs…

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,11 @@ matrix:
   include:
     - dist: trusty
       env: dist="14.04 LTS trusty"
-    - dist: xenial
-      env: dist="16.04 LTS xenial"
+#    - dist: xenial
+#      env: dist="16.04 LTS xenial"
+# Travis-CI only proposes 14.04 LTS Trusty and there is no plan to update to 16.04 xenial
+# (c.f. https://github.com/travis-ci/travis-ci/issues/5821)
+# It is useless to add a second job because it will run in the same Ubuntu version (14.04)
 
 before_install:
 - sudo apt-get update -qq


### PR DESCRIPTION
The travis-CI docs confirm the OS environment is "Ubuntu 14.04 LTS trusty".
Travis-CI only proposes 14.04 LTS Trusty and there is no plan to update to 16.04 xenial
(c.f. https://github.com/travis-ci/travis-ci/issues/5821)
It is not necessary to add a second job for "xenial" because it will run in the same environment.
This is what I find in the build log (and I also see all the installed packets are for "trusty")
(c.f. https://travis-ci.org/juangascon/mininet/jobs/286114955) :
(line 429) $ export dist="16.04 LTS xenial"
(...)
(line 450) Detected Linux distribution: Ubuntu 14.04 trusty amd64
(...)
(line 808) [0K$ bash -c "if [ `lsb_release -rs` == '14.04' ]; then make codecheck; fi"
(line 809) echo "Running code check"
(line 810) Running code check