### PR TITLE
replacing net-tools by iproute2

### DIFF
--- a/mininet/net.py
+++ b/mininet/net.py
@@ -18,7 +18,7 @@ A virtual console (pipes to a shell)
 A virtual interfaces (half of a veth pair)
 A parent shell (and possibly some child processes) in a namespace
 
-Hosts have a network interface which is configured via ifconfig/ip
+Hosts have a network interface which is configured via ip addr/ip
 link/etc.
 
 This version supports both the kernel and user space datapaths
@@ -903,10 +903,10 @@ class Mininet( object ):
             if len( connections ) == 0:
                 error( 'src and dst not connected: %s %s\n' % ( src, dst) )
             for srcIntf, dstIntf in connections:
-                result = srcIntf.ifconfig( status )
+                result = srcIntf.ipLink( status )
                 if result:
                     error( 'link src status change failed: %s\n' % result )
-                result = dstIntf.ifconfig( status )
+                result = dstIntf.ipLink( status )
                 if result:
                     error( 'link dst status change failed: %s\n' % result )
 

--- a/mininet/node.py
+++ b/mininet/node.py
@@ -590,7 +590,7 @@ class Node( object ):
         self.setParam( r, 'setIP', ip=ip )
         self.setParam( r, 'setDefaultRoute', defaultRoute=defaultRoute )
         # This should be examined
-        self.cmd( 'ifconfig lo ' + lo )
+        self.cmd( 'ip link set lo ' + lo )
         return r
 
     def configDefault( self, **moreParams ):
@@ -641,7 +641,7 @@ class Node( object ):
     @classmethod
     def setup( cls ):
         "Make sure our class dependencies are available"
-        pathCheck( 'mnexec', 'ifconfig', moduleName='Mininet')
+        pathCheck( 'mnexec', 'ip addr', moduleName='Mininet')
 
 class Host( Node ):
     "A host is simply a Node"
@@ -849,11 +849,11 @@ class CPULimitedHost( Host ):
 # normally never want to change its IP address!
 #
 # In general, you NEVER want to attempt to use Linux's
-# network stack (i.e. ifconfig) to "assign" an IP address or
+# network stack (i.e. iproute2) to "assign" an IP address or
 # MAC address to a switch data port. Instead, you "assign"
 # the IP and MAC addresses in the controller by specifying
 # packets that you want to receive or send. The "MAC" address
-# reported by ifconfig for a switch data port is essentially
+# reported by ip addr show for a switch data port is essentially
 # meaningless. It is important to understand this if you
 # want to create a functional router using OpenFlow.
 
@@ -1107,7 +1107,7 @@ class OVSSwitch( Switch ):
     def attach( self, intf ):
         "Connect a data port"
         self.vsctl( 'add-port', self, intf )
-        self.cmd( 'ifconfig', intf, 'up' )
+        self.cmd( 'ip link set', intf, 'up' )
         self.TCReapply( intf )
 
     def detach( self, intf ):


### PR DESCRIPTION
Net-tools is considered obsolete. Replacing it with iproute2 which is actively developed and, unlike net-tools, has support for all of the kernel networking stack's fancier features.

