### PR TITLE
More strict matching with `ifconfig` output.

### DIFF
--- a/mininet/link.py
+++ b/mininet/link.py
@@ -90,7 +90,7 @@ class Intf( object ):
                  self.ifconfig( 'hw', 'ether', macstr ) +
                  self.ifconfig( 'up' ) )
 
-    _ipMatchRegex = re.compile( r'\d+\.\d+\.\d+\.\d+' )
+    _ipMatchRegex = re.compile( r'(?<=inet addr:)\d+\.\d+\.\d+\.\d+' )
     _macMatchRegex = re.compile( r'..:..:..:..:..:..' )
 
     def updateIP( self ):


### PR DESCRIPTION
This PR proposes a stricter match with output from `ifconfig`.

Why do we need this? Currently mininet does not drain output fd before executing commands. So this means if there are IP addresses in the `stdout` already, then running `ifconfig` and regex matching will probably catch the stale output instead of the real one. And as is the case, many programs print IP addresses to `stdout`.

This PR proposes a stricter match os anything other than `ifconfig` will not get matched.

This is the case in CS 144 lab 4. Refer to [this post](https://piazza.com/class/j7v199jwgcu6mi?cid=924) for reproduction.