### PR TITLE
Set the datapath desciption (dp-desc) of OVS switches

### DIFF
--- a/mininet/node.py
+++ b/mininet/node.py
@@ -1160,6 +1160,7 @@ class OVSSwitch( Switch ):
             opts += ' protocols=%s' % self.protocols
         if self.stp and self.failMode == 'standalone':
             opts += ' stp_enable=true'
+        opts += ' other-config:dp-desc=%s' % self.name
         return opts
 
     def start( self, controllers ):


### PR DESCRIPTION
Mininet systematically sets datapath_id of the switches (e.g., name:s1 -> dp_id:1), yet a general purpose OpenFlow controller application cannot deduce a user-friendly information about a switch (for example, dp_id->name is not possible.)  This pull request sets the dp-desc to the name of the switch in case of ovs.  (A reply to an OFPMP_DESC message contains the dp-desc field.)  I think the new dp-desc value is more sensible than the current empty string.

(I'm a bit unsure whether this belongs to mininet or ovs, but it's definitely easier to implement it in mininet.)

Thanks.
