### PR TITLE
Fix switch setup not executing sometimes

### DIFF
--- a/mininet/node.py
+++ b/mininet/node.py
@@ -636,7 +636,7 @@ class Node( object ):
             cls.setup()
             cls.isSetup = True
             # Make pylint happy
-            cls = getattr( type( cls ), '__base__', None )
+            cls = getattr( cls, '__base__', None )
 
     @classmethod
     def setup( cls ):
@@ -863,6 +863,9 @@ class Switch( Node ):
 
     portBase = 1  # Switches start with port 1 in OpenFlow
     dpidLen = 16  # digits in dpid passed to switch
+    
+    # Prevent superclass from skipping switch setup
+    isSetup = False 
 
     def __init__( self, name, dpid=None, opts='', listenPort=None, **params):
         """dpid: dpid hex string (or None to derive from name, e.g. s1 -> 1)
@@ -1080,7 +1083,7 @@ class OVSSwitch( Switch ):
 
     @classmethod
     def isOldOVS( cls ):
-        "Is OVS ersion < 1.10?"
+        "Is OVS version < 1.10?"
         return ( StrictVersion( cls.OVSVersion ) <
                  StrictVersion( '1.10' ) )
 

--- a/mininet/node.py
+++ b/mininet/node.py
@@ -863,9 +863,9 @@ class Switch( Node ):
 
     portBase = 1  # Switches start with port 1 in OpenFlow
     dpidLen = 16  # digits in dpid passed to switch
-    
+
     # Prevent superclass from skipping switch setup
-    isSetup = False 
+    isSetup = False
 
     def __init__( self, name, dpid=None, opts='', listenPort=None, **params):
         """dpid: dpid hex string (or None to derive from name, e.g. s1 -> 1)

--- a/mininet/node.py
+++ b/mininet/node.py
@@ -864,7 +864,7 @@ class Switch( Node ):
     portBase = 1  # Switches start with port 1 in OpenFlow
     dpidLen = 16  # digits in dpid passed to switch
 
-    # Prevent superclass from skipping switch setup
+    # Prevents superclass from skipping OVSSwitch setup() call
     isSetup = False
 
     def __init__( self, name, dpid=None, opts='', listenPort=None, **params):
@@ -1035,6 +1035,9 @@ class UserSwitch( Switch ):
 
 class OVSSwitch( Switch ):
     "Open vSwitch switch. Depends on ovs-vsctl."
+
+    # Prevents superclass from skipping setup() call
+    isSetup = False
 
     def __init__( self, name, failMode='secure', datapath='kernel',
                   inband=False, protocols=None,


### PR DESCRIPTION
#784
When adding a node with the Node superclass before the switches nodes in the code, the switch setup function doesn't execute and we get an exception about OVSVersion not defined.
+ Adding another class variable (isSetup) to the Switch class to reinforce the check.
+ Also changing the superclasses check (checkSetup() function) that was checking metaclasses after the actual class setup.