### PR TITLE
Fix: Wrong switch count after save/load

### DIFF
--- a/examples/miniedit.py
+++ b/examples/miniedit.py
@@ -1386,7 +1386,7 @@ class MiniEdit( Frame ):
 
     def addNode( self, node, nodeNum, x, y, name=None):
         "Add a new node to our canvas."
-        if 'Switch' == node:
+        if 'Switch' == node or 'LegacySwitch' == node or 'LegacyRouter' == node:
             self.switchCount += 1
         if 'Host' == node:
             self.hostCount += 1


### PR DESCRIPTION
Bug appears if  a user ...
1. creates a topology with multiple `LegacySwitch` or `LegacyRouter` nodes (say `s1` and `s2`)
2. saves this topology
3. loads the topology again
4. adds an additional `LegacySwitch` or `LegacyRouter` or `Switch` to the loaded topology (the new switch will again be named `s1`)

The commit fixes this bug.