### PR TITLE
TCIntf returns handle of the parent for further queue addition using linux-tc

### DIFF
--- a/mininet/link.py
+++ b/mininet/link.py
@@ -43,6 +43,7 @@ class Intf( object ):
         self.link = link
         self.mac = mac
         self.ip, self.prefixLen = None, None
+        self.parent_queue = ' root '
 
         # if interface is lo, we know the ip is 127.0.0.1.
         # This saves an ifconfig command per node
@@ -278,6 +279,8 @@ class TCIntf( Intf ):
                           'burst 20 ' +
                           'bandwidth %fmbit probability 1' % bw ]
                 parent = ' parent 6: '
+        self.parent_queue = parent
+
         return cmds, parent
 
     @staticmethod
@@ -395,6 +398,7 @@ class TCIntf( Intf ):
         debug( "outputs:", tcoutputs, '\n' )
         result[ 'tcoutputs'] = tcoutputs
         result[ 'parent' ] = parent
+        self.parent_queue = parent
 
         return result
 


### PR DESCRIPTION
TCIntf class should return the handle for the parent queue after adding HTB queue for bandwidth and netem queue for delay, jitter and loss. So that user can manually attach more queues to the returned parent.