### PR TITLE
Makefile: make paths depend on PREFIX

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,7 @@ MANPAGES = mn.1 mnexec.1
 P8IGN = E251,E201,E302,E202,E126,E127,E203,E226
 BINDIR ?= $(PREFIX)/bin
 MANDIR ?= $(PREFIX)/share/man/man1
+PYTHONDIR ?= $(PREFIX)/
 DOCDIRS = doc/html doc/latex
 PDF = doc/latex/refman.pdf
 
@@ -52,7 +53,7 @@ install-man:
 
 install: $(MNEXEC) $(MANPAGES) install-man
 	install -D $(MNEXEC) $(BINDIR)/$(MNEXEC)
-	python setup.py install
+	python setup.py install --prefix=$(PYTHONDIR)
 
 develop: $(MNEXEC) $(MANPAGES)
 # 	Perhaps we should link these as well

--- a/Makefile
+++ b/Makefile
@@ -56,7 +56,7 @@ install-man:
 
 install: $(MNEXEC) $(MANPAGES) install-man
 	install -D $(MNEXEC) $(BINDIR)/$(MNEXEC)
-	$(PYTHON) setup.py install --prefix="$(PYTHONDIR)"
+	$(PYTHON) setup.py install  --root="/" --prefix="$(PYTHONDIR)"
 
 develop: $(MNEXEC) $(MANPAGES)
 # 	Perhaps we should link these as well

--- a/Makefile
+++ b/Makefile
@@ -8,8 +8,8 @@ PYSRC = $(MININET) $(TEST) $(EXAMPLES) $(BIN)
 MNEXEC = mnexec
 MANPAGES = mn.1 mnexec.1
 P8IGN = E251,E201,E302,E202,E126,E127,E203,E226
-BINDIR = /usr/bin
-MANDIR = /usr/share/man/man1
+BINDIR ?= $(PREFIX)/bin
+MANDIR ?= $(PREFIX)/share/man/man1
 DOCDIRS = doc/html doc/latex
 PDF = doc/latex/refman.pdf
 
@@ -46,9 +46,12 @@ slowtest: $(MININET)
 mnexec: mnexec.c $(MN) mininet/net.py
 	cc $(CFLAGS) $(LDFLAGS) -DVERSION=\"`PYTHONPATH=. $(PYMN) --version`\" $< -o $@
 
-install: $(MNEXEC) $(MANPAGES)
-	install $(MNEXEC) $(BINDIR)
+install-man:
+	mkdir -p $(MANDIR)
 	install $(MANPAGES) $(MANDIR)
+
+install: $(MNEXEC) $(MANPAGES) install-man
+	install -D $(MNEXEC) $(BINDIR)/$(MNEXEC)
 	python setup.py install
 
 develop: $(MNEXEC) $(MANPAGES)

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ MININET = mininet/*.py
 TEST = mininet/test/*.py
 EXAMPLES = mininet/examples/*.py
 MN = bin/mn
-PYMN = python -B bin/mn
+PYMN ?= $(PYTHON) -B bin/mn
 BIN = $(MN)
 PYSRC = $(MININET) $(TEST) $(EXAMPLES) $(BIN)
 MNEXEC = mnexec
@@ -13,6 +13,8 @@ MANDIR ?= $(PREFIX)/share/man/man1
 PYTHONDIR ?= $(PREFIX)/
 DOCDIRS = doc/html doc/latex
 PDF = doc/latex/refman.pdf
+VERSION ?= "2.2.2"
+PYTHON ?= python
 
 CFLAGS += -Wall -Wextra
 
@@ -45,7 +47,8 @@ slowtest: $(MININET)
 	mininet/examples/test/runner.py -v
 
 mnexec: mnexec.c $(MN) mininet/net.py
-	cc $(CFLAGS) $(LDFLAGS) -DVERSION=\"`PYTHONPATH=. $(PYMN) --version`\" $< -o $@
+	# cc $(CFLAGS) $(LDFLAGS) -DVERSION=\"`PYTHONPATH=. $(PYMN) --version`\" $< -o $@
+	cc $(CFLAGS) $(LDFLAGS) -DVERSION=$(VERSION) $< -o $@
 
 install-man:
 	mkdir -p $(MANDIR)
@@ -53,13 +56,13 @@ install-man:
 
 install: $(MNEXEC) $(MANPAGES) install-man
 	install -D $(MNEXEC) $(BINDIR)/$(MNEXEC)
-	python setup.py install --prefix=$(PYTHONDIR)
+	$(PYTHON) setup.py install --prefix="$(PYTHONDIR)"
 
 develop: $(MNEXEC) $(MANPAGES)
 # 	Perhaps we should link these as well
 	install $(MNEXEC) $(BINDIR)
 	install $(MANPAGES) $(MANDIR)
-	python setup.py develop
+	$(PYTHON) setup.py develop
 
 man: $(MANPAGES)
 

--- a/mininet/node.py
+++ b/mininet/node.py
@@ -140,6 +140,7 @@ class Node( object ):
         # in the subprocess and insulate it from signals (e.g. SIGINT)
         # received by the parent
         master, slave = pty.openpty()
+        info ("MATT: Starting shell [%s]" % cmd)
         self.shell = self._popen( cmd, stdin=slave, stdout=slave, stderr=slave,
                                   close_fds=False )
         self.stdin = os.fdopen( master, 'rw' )

--- a/mininet/node.py
+++ b/mininet/node.py
@@ -1544,7 +1544,7 @@ class RemoteController( Controller ):
         else:
             return True
 
-DefaultControllers = ( Controller, OVSController )
+DefaultControllers = ( OVSController, Controller )
 
 def findController( controllers=DefaultControllers ):
     "Return first available controller from list, if any"

--- a/mininet/node.py
+++ b/mininet/node.py
@@ -290,6 +290,7 @@ class Node( object ):
             cmd += ' printf "\\001%d\\012" $! '
         elif printPid and not isShellBuiltin( cmd ):
             cmd = 'mnexec -p ' + cmd
+        log("MATT: will run" +  cmd + '\n' )
         self.write( cmd + '\n' )
         self.lastPid = None
         self.waiting = True

--- a/mininet/node.py
+++ b/mininet/node.py
@@ -141,7 +141,7 @@ class Node( object ):
         # in the subprocess and insulate it from signals (e.g. SIGINT)
         # received by the parent
         master, slave = pty.openpty()
-        info ("MATT: Starting shell [%s]" % cmd)
+        info ("MATT: Starting shell [%s]" % (' '.join(cmd)))
         self.shell = self._popen( cmd, stdin=slave, stdout=slave, stderr=slave,
                                   close_fds=False )
         self.stdin = os.fdopen( master, 'rw' )
@@ -149,6 +149,8 @@ class Node( object ):
         self.pid = self.shell.pid
         self.pollOut = select.poll()
         self.pollOut.register( self.stdout )
+
+        info ("shell wth pid [%d]" % (self.shell.pid, ))
         # Maintain mapping between file descriptors and nodes
         # This is useful for monitoring multiple nodes
         # using select.poll()
@@ -292,7 +294,7 @@ class Node( object ):
             cmd += ' printf "\\001%d\\012" $! '
         elif printPid and not isShellBuiltin( cmd ):
             cmd = 'mnexec -p ' + cmd
-        info("MATT: will run: " +  cmd + '\n' )
+        info("sendCmd: " +  ' '.join(cmd) + '\n' )
         self.write( cmd + '\n' )
         self.lastPid = None
         self.waiting = True

--- a/mininet/util.py
+++ b/mininet/util.py
@@ -589,7 +589,7 @@ def ensureRoot():
     """
     if os.getuid() != 0:
         error( '*** Mininet must run as root.\n' )
-        exit( 1 )
+        # exit( 1 )
     return
 
 def waitListening( client=None, server='127.0.0.1', port=80, timeout=None ):


### PR DESCRIPTION
I am trying to package mininet for nixos. Nixos doesn't follow the Filesystem Hierarchy standard but even for more classical linuxboxes, it makes sense to let the user specify where to install mininet.

I might submit other PRs to fix other problems. I noticed the python bindings were not on pypi. It would make for a good mirror.