### PR TITLE
more flexible Makefile 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,8 +8,9 @@ PYSRC = $(MININET) $(TEST) $(EXAMPLES) $(BIN)
 MNEXEC = mnexec
 MANPAGES = mn.1 mnexec.1
 P8IGN = E251,E201,E302,E202,E126,E127,E203,E226
-BINDIR = /usr/bin
-MANDIR = /usr/share/man/man1
+PREFIX ?= /usr
+BINDIR ?= $(PREFIX)/bin
+MANDIR ?= $(PREFIX)/share/man/man1
 DOCDIRS = doc/html doc/latex
 PDF = doc/latex/refman.pdf
 
@@ -46,9 +47,13 @@ slowtest: $(MININET)
 mnexec: mnexec.c $(MN) mininet/net.py
 	cc $(CFLAGS) $(LDFLAGS) -DVERSION=\"`PYTHONPATH=. $(PYMN) --version`\" $< -o $@
 
-install: $(MNEXEC) $(MANPAGES)
-	install $(MNEXEC) $(BINDIR)
-	install $(MANPAGES) $(MANDIR)
+install-mnexec: $(MNEXEC)
+	install -D $(MNEXEC) $(BINDIR)/$(MNEXEC)
+
+install-manpages: $(MANPAGES)
+	install -D -t $(MANDIR) $(MANPAGES)
+
+install: install-mnexec install-manpages
 	python setup.py install
 
 develop: $(MNEXEC) $(MANPAGES)

--- a/mininet/node.py
+++ b/mininet/node.py
@@ -135,7 +135,9 @@ class Node( object ):
         # -s: pass $* to shell, and make process easy to find in ps
         # prompt is set to sentinel chr( 127 )
         cmd = [ 'mnexec', opts, 'env', 'PS1=' + chr( 127 ),
-                'bash', '--norc', '-is', 'mininet:' + self.name ]
+                'bash', '--norc', '--noediting',
+                '-is', 'mininet:' + self.name ]
+
         # Spawn a shell subprocess in a pseudo-tty, to disable buffering
         # in the subprocess and insulate it from signals (e.g. SIGINT)
         # received by the parent


### PR DESCRIPTION
I packaged mininet for www.nixos.org with these changes. 

The only intended breaking change is that one has to run `make install install-python` instead of `make install` but I can revert this if needed. Dealing with python can be very annoying so I wanted to break that dependency.