### PR TITLE
replace netbee download link

### DIFF
--- a/util/install.sh
+++ b/util/install.sh
@@ -225,10 +225,8 @@ function of13 {
         NBEESRC="nbeesrc-jan-10-2013"
         NBEEDIR="nbeesrc-jan-10-2013"
     fi
-
-    NBEEURL=${NBEEURL:-http://www.nbee.org/download/}
-    wget -nc ${NBEEURL}${NBEESRC}.zip
-    unzip ${NBEESRC}.zip
+   
+    git clone https://github.com/jjones646/netbee -o ${NBEEDIR}
     cd ${NBEEDIR}/src
     cmake .
     make


### PR DESCRIPTION
Since netbee link is not active anymore , http://www.nbee.org/download/ returns a 404 http error.
Hence replacing this by a git clone https://github.com/jjones646/netbee.
As given in the description `this repo is a copy of the NetBee source code`