### PR TITLE
MakeIntfPair allows now to set a single mac address

### DIFF
--- a/mininet/util.py
+++ b/mininet/util.py
@@ -218,17 +218,12 @@ def makeIntfPair( intf1, intf2, addr1=None, addr2=None, node1=None, node2=None,
         runCmd2( 'ip link del ' + intf2 )
     # Create new pair
     netns = 1 if not node2 else node2.pid
-    if addr1 is None and addr2 is None:
-        cmdOutput = runCmd( 'ip link add name %s '
-                            'type veth peer name %s '
-                            'netns %s' % ( intf1, intf2, netns ) )
-    else:
-        cmdOutput = runCmd( 'ip link add name %s '
-                            'address %s '
-                            'type veth peer name %s '
-                            'address %s '
-                            'netns %s' %
-                            (  intf1, addr1, intf2, addr2, netns ) )
+
+    addr1 = "address %s " % addr1 if addr1 else ""
+    addr2 = "address %s " % addr2 if addr2 else ""
+    cmd = 'ip link add name %s %stype veth peer name %s %snetns %s' % ( intf1, addr1, intf2, addr2, netns )
+    cmdOutput = runCmd(cmd)
+    
     if cmdOutput:
         raise Exception( "Error creating interface pair (%s,%s): %s " %
                          ( intf1, intf2, cmdOutput ) )


### PR DESCRIPTION
In the current implementation if you do `addLink` and you can only specify the mac address of the interfaces if you set it for both `addr1` and `addr2`. If you just set one of them, the other will be added as `None` and the `ip link` command fails.

This PR allows you to add links and just specify one `mac` address, the other will be set randomly. 