### PR TITLE
Replaced example topologies __init__ with build

### DIFF
--- a/custom/topo-2sw-2host.py
+++ b/custom/topo-2sw-2host.py
@@ -13,11 +13,8 @@ from mininet.topo import Topo
 class MyTopo( Topo ):
     "Simple topology example."
 
-    def __init__( self ):
+    def build( self ):
         "Create custom topo."
-
-        # Initialize topology
-        Topo.__init__( self )
 
         # Add hosts and switches
         leftHost = self.addHost( 'h1' )

--- a/examples/controlnet.py
+++ b/examples/controlnet.py
@@ -100,7 +100,7 @@ class MininetFacade( object ):
 
 class ControlNetwork( Topo ):
     "Control Network Topology"
-    def build( self, n, dataController=DataController, **kwargs ):
+    def build( self, n, dataController=DataController, **_kwargs ):
         """n: number of data network controller nodes
            dataController: class for data network controllers"""
         # Connect everything to a single switch

--- a/examples/controlnet.py
+++ b/examples/controlnet.py
@@ -100,10 +100,9 @@ class MininetFacade( object ):
 
 class ControlNetwork( Topo ):
     "Control Network Topology"
-    def __init__( self, n, dataController=DataController, **kwargs ):
+    def build( self, n, dataController=DataController, **kwargs ):
         """n: number of data network controller nodes
            dataController: class for data network controllers"""
-        Topo.__init__( self, **kwargs )
         # Connect everything to a single switch
         cs0 = self.addSwitch( 'cs0' )
         # Add hosts which will serve as data network controllers

--- a/examples/linearbandwidth.py
+++ b/examples/linearbandwidth.py
@@ -38,11 +38,7 @@ flush = sys.stdout.flush
 class LinearTestTopo( Topo ):
     "Topology for a string of N hosts and N-1 switches."
 
-    def __init__( self, N, **params ):
-
-        # Initialize topology
-        Topo.__init__( self, **params )
-
+    def build( self, N, **params ):
         # Create switches and hosts
         hosts = [ self.addHost( 'h%s' % h )
                   for h in irange( 1, N ) ]

--- a/examples/multilink.py
+++ b/examples/multilink.py
@@ -21,9 +21,7 @@ def runMultiLink():
 class simpleMultiLinkTopo( Topo ):
     "Simple topology with multiple links"
 
-    def __init__( self, n, **kwargs ):
-        Topo.__init__( self, **kwargs )
-
+    def build( self, n, **kwargs ):
         h1, h2 = self.addHost( 'h1' ), self.addHost( 'h2' )
         s1 = self.addSwitch( 's1' )
 

--- a/examples/multilink.py
+++ b/examples/multilink.py
@@ -21,7 +21,7 @@ def runMultiLink():
 class simpleMultiLinkTopo( Topo ):
     "Simple topology with multiple links"
 
-    def build( self, n, **kwargs ):
+    def build( self, n, **_kwargs ):
         h1, h2 = self.addHost( 'h1' ), self.addHost( 'h2' )
         s1 = self.addSwitch( 's1' )
 

--- a/examples/natnet.py
+++ b/examples/natnet.py
@@ -27,9 +27,7 @@ from mininet.util import irange
 
 class InternetTopo(Topo):
     "Single switch connected to n hosts."
-    def __init__(self, n=2, **opts):
-        Topo.__init__(self, **opts)
-
+    def build(self, n=2, **opts):
         # set up inet switch
         inetSwitch = self.addSwitch('s0')
         # add inet host

--- a/examples/natnet.py
+++ b/examples/natnet.py
@@ -27,7 +27,7 @@ from mininet.util import irange
 
 class InternetTopo(Topo):
     "Single switch connected to n hosts."
-    def build(self, n=2, **opts):
+    def build(self, n=2, **_kwargs ):
         # set up inet switch
         inetSwitch = self.addSwitch('s0')
         # add inet host


### PR DESCRIPTION
Moved example topology construction from init to build, as proposed in #825 