### PR TITLE
Fix occasional exception on mn exit

### DIFF
--- a/mininet/cli.py
+++ b/mininet/cli.py
@@ -87,7 +87,7 @@ class CLI( Cmd ):
             history_path = os.path.expanduser( '~/.mininet_history' )
             if os.path.isfile( history_path ):
                 read_history_file( history_path )
-                set_history_length( 1000 )
+                set_history_length( -1 )
             atexit.register( lambda: write_history_file( history_path ) )
 
     def run( self ):


### PR DESCRIPTION
We can fix #821 by setting the command history length to infinite.