### PR TITLE
change isShellBuiltin

### DIFF
--- a/mininet/util.py
+++ b/mininet/util.py
@@ -181,7 +181,7 @@ def which(cmd, **kwargs ):
 def isShellBuiltin( cmd ):
     "Return True if cmd is a bash builtin."
     if isShellBuiltin.builtIns is None:
-        isShellBuiltin.builtIns = quietRun( 'bash -c enable' )
+        isShellBuiltin.builtIns = set(quietRun( 'bash -c enable' ).split())
     space = cmd.find( ' ' )
     if space > 0:
         cmd = cmd[ :space]


### PR DESCRIPTION
change isShellBuiltin to have each builtin as a different token in a set and lookup cmd to be an element of the set instead of a sequence of characters in a string (tested only on Python 3.6.7). Corrected according to @lantz comments.