### PR TITLE
make it easier to set the compiler

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,7 @@ BINDIR ?= $(PREFIX)/bin
 MANDIR ?= $(PREFIX)/share/man/man1
 DOCDIRS = doc/html doc/latex
 PDF = doc/latex/refman.pdf
+CC ?= cc
 
 CFLAGS += -Wall -Wextra
 
@@ -46,7 +47,7 @@ slowtest: $(MININET)
 	mininet/examples/test/runner.py -v
 
 mnexec: mnexec.c $(MN) mininet/net.py
-	cc $(CFLAGS) $(LDFLAGS) -DVERSION=\"`PYTHONPATH=. $(PYMN) --version`\" $< -o $@
+	$(CC) $(CFLAGS) $(LDFLAGS) -DVERSION=\"`PYTHONPATH=. $(PYMN) --version`\" $< -o $@
 
 install-mnexec: $(MNEXEC)
 	install -D $(MNEXEC) $(BINDIR)/$(MNEXEC)


### PR DESCRIPTION
Hi, I'm trying to package Mininet for Guix which doesn't symlink cc to gcc and this would make it easier to package, as well as configure it for alternative compilers.