### PR TITLE
LinuxBridge allow arbitrarily named interfaces

### DIFF
--- a/mininet/nodelib.py
+++ b/mininet/nodelib.py
@@ -42,8 +42,7 @@ class LinuxBridge( Switch ):
             self.cmd( 'brctl setbridgeprio', self.prio )
             self.cmd( 'brctl stp', self, 'on' )
         for i in self.intfList():
-            if self.name in i.name:
-                self.cmd( 'brctl addif', self, i )
+            self.cmd( 'brctl addif', self, i )
         self.cmd( 'ifconfig', self, 'up' )
 
     def stop( self, deleteIntfs=True ):


### PR DESCRIPTION
Removed unnecessary filter which only allowed interfaces
named like `BRIDGENAME-*` (e.g. `s1-eth1`) to be added
to bridge (class `OVSSwitch` does not have a filter like that,
so `LinuxBridge` also should not have it). Thus, now e.g. real
interfaces like `eth0` can be added to bridge.

In more detail: Like `examples/hwintf.py` demonstrates, it is possible to add e.g. real network interfaces like `eth0` to an instance of `OVSSwitch` or `OVSBridge`, however that did not work with `LinuxBridge`. This PR fixes that.

Example script to reproduce the issue:
```
#!/usr/bin/python
import mininet.net
import mininet.log
import mininet.cli
import mininet.link
import mininet.nodelib

MYNIC='eth0'

mininet.log.setLogLevel('debug')
net = mininet.net.Mininet()
h1 = net.addHost('h1')
h2 = net.addHost('h2')
#s1 = net.addSwitch('s1', cls=mininet.node.OVSBridge)
s1 = net.addSwitch('s1', cls=mininet.nodelib.LinuxBridge)
net.addLink(h1, s1)
net.addLink(h2, s1)
mininet.link.Intf(MYNIC, node=s1)
net.start()
mininet.cli.CLI(net)
net.stop()
```

Or are there other usage scenarios where enforcing of interface names like `s1-eth1` is important? I guess not, or else `OVSSwitch` would enforce this, too.