### PR TITLE
Make node.cmd() more robust.

### DIFF
--- a/mininet/node.py
+++ b/mininet/node.py
@@ -370,6 +370,11 @@ class Node( object ):
         log = info if verbose else debug
         log( '*** %s : %s\n' % ( self.name, args ) )
         if self.shell:
+            self.shell.poll()
+            if self.shell.returncode is not None:
+                warn(" cmd: shell died on %s\n" % self.name)
+                self.shell = None
+                self.startShell()
             self.sendCmd( *args, **kwargs )
             return self.waitOutput( verbose )
         else:


### PR DESCRIPTION
I have an environment where different nodes may call `net.stop()` and `sudo mn -c` to clean up mininet. Unfortunately, it seems that `net.stop()`  gets stuck  if `sudo mn -c` has been called in the meantime. The code to reproduce this issue is as follows:

```
import os
from mininet.net import Mininet
from mininet.topo import SingleSwitchTopo
from mininet.log import setLogLevel

def test_net(hosts):
    topo = SingleSwitchTopo(hosts)
    net = Mininet(topo=topo, controller=None)
    net.start()
    os.system('sudo mn -c')
    net.stop()

if __name__ == '__main__':
    setLogLevel('info')
    test_net(hosts=3)
```

This pull request is intended to make the node.cmd() call more robust to ensure that it does not crash anymore. 
This file change is taken from changes in [containernet](https://github.com/containernet/containernet) (@mpeuster). Please let me know what you think. 