### PR TITLE
Don't pass 'loss 0' to tc as it will cause an error on newer versions

### DIFF
--- a/mininet/link.py
+++ b/mininet/link.py
@@ -295,7 +295,7 @@ class TCIntf( Intf ):
             netemargs = '%s%s%s%s' % (
                 'delay %s ' % delay if delay is not None else '',
                 '%s ' % jitter if jitter is not None else '',
-                'loss %.5f ' % loss if loss is not None else '',
+                'loss %.5f ' % loss if (loss is not None and loss > 0) else '',
                 'limit %d' % max_queue_size if max_queue_size is not None
                 else '' )
             if netemargs:


### PR DESCRIPTION
Observed on Ubuntu 18.04.