### PR TITLE
Changed defaultIntf to evaluate to first UP-state interface

### DIFF
--- a/mininet/node.py
+++ b/mininet/node.py
@@ -460,7 +460,7 @@ class Node( object ):
 
     def defaultIntf( self ):
         "Return interface for lowest port"
-        ports = self.intfs.keys()
+        ports = [i for i in self.intfs.keys() if self.intfs[i].isUp()]
         if ports:
             return self.intfs[ min( ports ) ]
         else:


### PR DESCRIPTION
By default, defaultIntf() always returns the first interface found on a node.
We can change this by applying a simple filter to remove interfaces that are DOWN, so now it returns the first UP state interface.
Example: Node h1 has multiple interfaces h1-eth0, h1-eth1 etc. 
If h1-eth0 is down and h1-eth1 is up then with this modification it returns h1-eth1 instead of h1-eth0.
This helps if you try to ping eg. h2 ping h1 which fails without this modification if the interface returned is DOWN. 
A simple paradigm of where this could be useful can be found in #865 .
