### PR TITLE
Use incremental utf-8 decoder for buffered reading

### DIFF
--- a/mininet/node.py
+++ b/mininet/node.py
@@ -63,7 +63,7 @@ from time import sleep
 from mininet.log import info, error, warn, debug
 from mininet.util import ( quietRun, errRun, errFail, moveIntf, isShellBuiltin,
                            numCores, retry, mountCgroups, BaseString, decode,
-                           encode, Python3, which )
+                           encode, getincrementaldecoder, Python3, which )
 from mininet.moduledeps import moduleDeps, pathCheck, TUN
 from mininet.link import Link, Intf, TCIntf, OVSIntf
 from re import findall
@@ -105,6 +105,9 @@ class Node( object ):
                 None, None, None, None, None, None, None, None )
         self.waiting = False
         self.readbuf = ''
+
+        # Incremental decoder for buffered reading
+        self.decoder = getincrementaldecoder()
 
         # Start command interpreter shell
         self.master, self.slave = None, None  # pylint
@@ -229,19 +232,19 @@ class Node( object ):
 
     # Subshell I/O, commands and control
 
-    def read( self, maxbytes=1024 ):
+    def read( self, size=1024 ):
         """Buffered read from node, potentially blocking.
-           maxbytes: maximum number of bytes to return"""
+           size: maximum number of characters to return"""
         count = len( self.readbuf )
-        if count < maxbytes:
-            data = decode( os.read( self.stdout.fileno(), maxbytes - count ) )
-            self.readbuf += data
-        if maxbytes >= len( self.readbuf ):
+        if count < size:
+            data = os.read( self.stdout.fileno(), size - count )
+            self.readbuf += self.decoder.decode( data )
+        if size >= len( self.readbuf ):
             result = self.readbuf
             self.readbuf = ''
         else:
-            result = self.readbuf[ :maxbytes ]
-            self.readbuf = self.readbuf[ maxbytes: ]
+            result = self.readbuf[ :size ]
+            self.readbuf = self.readbuf[ size: ]
         return result
 
     def readline( self ):


### PR DESCRIPTION
Only tested on Python 3.

Renamed the argument `maxbytes` to `size` because `len` counts the number of characters in a Python 3 string, not the number of bytes.

EDIT: Relates to issue #890.