### PR TITLE
Return the new link key in Topo.addLink()

### DIFF
--- a/mininet/topo.py
+++ b/mininet/topo.py
@@ -156,8 +156,7 @@ class Topo( object ):
         port1, port2 = self.addPort( node1, node2, port1, port2 )
         opts = dict( opts )
         opts.update( node1=node1, node2=node2, port1=port1, port2=port2 )
-        self.g.add_edge(node1, node2, key, opts )
-        return key
+        return self.g.add_edge(node1, node2, key, opts )
 
     def nodes( self, sort=True ):
         "Return nodes in graph"


### PR DESCRIPTION
The Topo.addLink() method does not respect its specifications. It does not return the key to the graph edge if the key parameter was not set. In that case, it will always return None. This patch updates the key variable to prevent that.

This issue was introduced by PR #416 