### PR TITLE
Check isSetup for Switches

### DIFF
--- a/mininet/node.py
+++ b/mininet/node.py
@@ -881,7 +881,7 @@ class CPULimitedHost( Host ):
 class Switch( Node ):
     """A Switch is a Node that is running (or has execed?)
        an OpenFlow switch."""
-    
+
     isSetup = False # Automatic class setup support
     portBase = 1  # Switches start with port 1 in OpenFlow
     dpidLen = 16  # digits in dpid passed to switch


### PR DESCRIPTION
Assuming that the first node added is from `Node` class, `isSetup` is True even when the second node is a Switch. Therefore, it is necessary to check if `isSetup` is True within the `Switch` class.

**How can I reproduce the error?**
In practical terms, this throws an error:
```h1 = net.addHost('h1', cls=Node)```
```s1 = net.addSwitch('s1', cls=OVSSwitch)```

```File "build/bdist.linux-x86_64/egg/mininet/node.py", line 1200, in start
File "build/bdist.linux-x86_64/egg/mininet/node.py", line 1201, in <genexpr>
File "build/bdist.linux-x86_64/egg/mininet/node.py", line 1166, in intfOpts
File "build/bdist.linux-x86_64/egg/mininet/node.py", line 1109, in isOldOVS
AttributeError: type object 'OVSSwitch' has no attribute 'OVSVersion'
```

and this works fine:
```h1 = net.addHost('h1', cls=Host)```
```s1 = net.addSwitch('s1', cls=OVSSwitch)```