### PR TITLE
Fix for install.sh on Ubuntu 19.10

### DIFF
--- a/util/install.sh
+++ b/util/install.sh
@@ -172,9 +172,10 @@ function mn_deps {
                         python-pep8 ${PYPKG}-pexpect ${PYPKG}-tk
     else  # Debian/Ubuntu
         $install gcc make socat psmisc xterm ssh iperf telnet \
-                 cgroup-bin ethtool help2man pyflakes pylint pep8 \
+                 ethtool help2man pyflakes pylint pep8 \
                  ${PYPKG}-setuptools ${PYPKG}-pexpect ${PYPKG}-tk
         $install iproute2 || $install iproute
+        $install cgroup-tools || cgroup-bin
     fi
 
     echo "Installing Mininet core"


### PR DESCRIPTION
Substitute cgroup-bin with cgroup-tools for Debian/Ubuntu.

Reason: cgroup-bin is only a transitional package on all 'modern' versions of Debian and Ubuntu.
It does not exist on Ubuntu 19.10 any more, thus `utils/install.sh -n` fails.