### PR TITLE
Fix install.sh on Ubuntu 19.10: substitute cgroup-bin with cgroup-too…

### DIFF
--- a/util/install.sh
+++ b/util/install.sh
@@ -172,9 +172,10 @@ function mn_deps {
                         python-pep8 ${PYPKG}-pexpect ${PYPKG}-tk
     else  # Debian/Ubuntu
         $install gcc make socat psmisc xterm ssh iperf telnet \
-                 cgroup-bin ethtool help2man pyflakes pylint pep8 \
+                 ethtool help2man pyflakes pylint pep8 \
                  ${PYPKG}-setuptools ${PYPKG}-pexpect ${PYPKG}-tk
         $install iproute2 || $install iproute
+        $install cgroup-tools || $install cgroup-bin
     fi
 
     echo "Installing Mininet core"


### PR DESCRIPTION
…ls for Debian/Ubuntu

On Debian 8 and later and Ubuntu 16.04LTS, `cgroup-bin` is a transitional package for `cgroup-tools`.
On Ubunutu 19.10, cgroup-bin is not available any more thus install.sh crashes.

As a solution, attempt to install `cgroup-tools` instead of `cgroup-bin`.