### PR TITLE
change to fix flake8 F632 issues

### DIFF
--- a/examples/miniedit.py
+++ b/examples/miniedit.py
@@ -2247,7 +2247,7 @@ class MiniEdit( Frame ):
 
     def clickNode( self, event ):
         "Node click handler."
-        if self.active is 'NetLink':
+        if self.active == 'NetLink':
             self.startLink( event )
         else:
             self.selectNode( event )
@@ -2255,14 +2255,14 @@ class MiniEdit( Frame ):
 
     def dragNode( self, event ):
         "Node drag handler."
-        if self.active is 'NetLink':
+        if self.active == 'NetLink':
             self.dragNetLink( event )
         else:
             self.dragNodeAround( event )
 
     def releaseNode( self, event ):
         "Node release handler."
-        if self.active is 'NetLink':
+        if self.active == 'NetLink':
             self.finishLink( event )
 
     # Specific node handlers

--- a/mininet/cli.py
+++ b/mininet/cli.py
@@ -144,7 +144,7 @@ class CLI( Cmd ):
     def do_help( self, line ):
         "Describe available CLI commands."
         Cmd.do_help( self, line )
-        if line is '':
+        if line == '':
             output( self.helpStr )
 
     def do_nodes( self, _line ):
@@ -444,7 +444,7 @@ class CLI( Cmd ):
                 # XXX BL: this doesn't quite do what we want.
                 if False and self.inputFile:
                     key = self.inputFile.read( 1 )
-                    if key is not '':
+                    if key != '':
                         node.write( key )
                     else:
                         self.inputFile = None


### PR DESCRIPTION
Originally brought up in the `flake8` output of #910 

`is` isnt a great way to test equality of a string :
https://stackoverflow.com/questions/1504717/why-does-comparing-strings-using-either-or-is-sometimes-produce-a-differe

PR changes string equality checks to use `==` and `!=` getting rid of the F632 flake8 warnings.