### PR TITLE
change to use 0o for octal numbers w/ file permissons for python2/3 compatibility 

### DIFF
--- a/util/vm/build.py
+++ b/util/vm/build.py
@@ -179,7 +179,7 @@ def findiso( flavor ):
     url = isoURLs[ flavor ]
     name = path.basename( url )
     iso = path.join( VMImageDir, name )
-    if not path.exists( iso ) or ( stat( iso )[ ST_MODE ] & 0777 != 0444 ):
+    if not path.exists( iso ) or ( stat( iso )[ ST_MODE ] & 0o777 != 0o444 ):
         log( '* Retrieving', url )
         run( 'curl -C - -o %s %s' % ( iso, url ) )
         # Make sure the file header/type is something reasonable like

--- a/util/vm/build.py
+++ b/util/vm/build.py
@@ -190,7 +190,7 @@ def findiso( flavor ):
             raise Exception( 'findiso: could not download iso from ' + url )
         # Write-protect iso, signaling it is complete
         log( '* Write-protecting iso', iso)
-        os.chmod( iso, 0444 )
+        os.chmod( iso, 0o444 )
     log( '* Using iso', iso )
     return iso
 
@@ -222,7 +222,7 @@ def extractKernel( image, flavor, imageDir=VMImageDir ):
     "Extract kernel and initrd from base image"
     kernel = path.join( imageDir, flavor + '-vmlinuz' )
     initrd = path.join( imageDir, flavor + '-initrd' )
-    if path.exists( kernel ) and ( stat( image )[ ST_MODE ] & 0777 ) == 0444:
+    if path.exists( kernel ) and ( stat( image )[ ST_MODE ] & 0o777 ) == 0o444:
         # If kernel is there, then initrd should also be there
         return kernel, initrd
     log( '* Extracting kernel to', kernel )
@@ -252,8 +252,8 @@ def findBaseImage( flavor, size='8G' ):
     image = path.join( VMImageDir, flavor + '-base.qcow2' )
     if path.exists( image ):
         # Detect race condition with multiple builds
-        perms = stat( image )[ ST_MODE ] & 0777
-        if perms != 0444:
+        perms = stat( image )[ ST_MODE ] & 0o777
+        if perms != 0o444:
             raise Exception( 'Error - base image %s is writable.' % image +
                              ' Are multiple builds running? if not,'
                              ' remove %s and try again.' % image )
@@ -266,7 +266,7 @@ def findBaseImage( flavor, size='8G' ):
         installUbuntu( iso, image )
         # Write-protect image, also signaling it is complete
         log( '* Write-protecting image', image)
-        os.chmod( image, 0444 )
+        os.chmod( image, 0o444 )
     kernel, initrd = extractKernel( image, flavor )
     log( '* Using base image', image, 'and kernel', kernel )
     return image, kernel, initrd


### PR DESCRIPTION
# Description 

Brought up in #910, running `flake8` we see the following error:

```
$ flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
./util/vm/build.py:182:64: E999 SyntaxError: invalid token
    if not path.exists( iso ) or ( stat( iso )[ ST_MODE ] & 0777 != 0444 ):
                                                               ^
```
Seems that `0777` and `0444` are valid tokens in python2.7 but not in python3+:
However `0o777` and `0o444` are valid in both python 2 and 3.
This PR changes it to use `0o`. 

```
(base) Shans-MBP:mininet ssikdar1$ python2.7
Python 2.7.10 (default, Feb 22 2019, 21:55:15) 
[GCC 4.2.1 Compatible Apple LLVM 10.0.1 (clang-1001.0.37.14)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> 0777
511
>>> 0444
292
>>> 0o777
511
>>> 0o444 
292
>>> ^D
(base) Shans-MBP:mininet ssikdar1$ 
(base) Shans-MBP:mininet ssikdar1$ python3
Python 3.7.3 (default, Mar 27 2019, 16:54:48) 
[Clang 4.0.1 (tags/RELEASE_401/final)] :: Anaconda, Inc. on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> 0777
  File "<stdin>", line 1
    0777
       ^
SyntaxError: invalid token
>>> 0444
  File "<stdin>", line 1
    0444
       ^
SyntaxError: invalid token
>>> 0o777
511
>>> 0o444 
292
>>> 
(base) Shans-MBP:mininet ssikdar1$ 
```

Related stackoverflow's and python test links showing `0o777` is valid.

https://stackoverflow.com/a/17776766/1730064
https://stackoverflow.com/questions/36745577/how-do-you-create-in-python-a-file-with-permissions-other-users-can-write
https://github.com/python/cpython/blob/2.7/Lib/test/test_compile.py#L287
https://github.com/python/cpython/blob/6c3e66a34b95fff07df0ad5086104dd637a091ce/Lib/test/test_compile.py#L189


