### PR TITLE
change execfile for  python2/3 compatibility 

### DIFF
--- a/examples/miniedit.py
+++ b/examples/miniedit.py
@@ -47,6 +47,7 @@ else:
     from tkinter import font as tkFont
     from tkinter import simpledialog as tkSimpleDialog
     from tkinter import filedialog as tkFileDialog
+
 # pylint: enable=import-error
 
 import re
@@ -3221,11 +3222,14 @@ class MiniEdit( Frame ):
             # Add or modify global variable or class
             globals()[ name ] = value
 
+
     def parseCustomFile( self, fileName ):
         "Parse custom file and add params before parsing cmd-line options."
         customs = {}
         if os.path.isfile( fileName ):
-            execfile( fileName, customs, customs )
+            with open(fileName) as f:
+                code = compile(f.read(), fileName, 'exec')
+                exec(code, customs, customs) # pylint: disable=W0122
             for name, val in customs.items():
                 self.setCustom( name, val )
         else:

--- a/examples/miniedit.py
+++ b/examples/miniedit.py
@@ -47,7 +47,6 @@ else:
     from tkinter import font as tkFont
     from tkinter import simpledialog as tkSimpleDialog
     from tkinter import filedialog as tkFileDialog
-
 # pylint: enable=import-error
 
 import re
@@ -3221,7 +3220,6 @@ class MiniEdit( Frame ):
         else:
             # Add or modify global variable or class
             globals()[ name ] = value
-
 
     def parseCustomFile( self, fileName ):
         "Parse custom file and add params before parsing cmd-line options."


### PR DESCRIPTION
# Description

Trying to run `make` with python3 results in an error: 
```
mininet/examples/miniedit.py:3228: undefined name 'execfile'
```

Apparently, in `execfile` was removed in python3+:

```
$ python
Python 3.7.3 (default, Mar 27 2019, 16:54:48) 
[Clang 4.0.1 (tags/RELEASE_401/final)] :: Anaconda, Inc. on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> execfile
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
NameError: name 'execfile' is not defined
```

Looking at this stack overflow link:
https://stackoverflow.com/questions/436198/what-is-an-alternative-to-execfile-in-python-3

and the source code for pythons lib 2to3 (https://docs.python.org/2/library/2to3.html):

https://github.com/python/cpython/blob/276a84a0a6c694ce227bf36ec2e2e6ec6686170f/Lib/lib2to3/tests/test_fixers.py#L1211-L1213

It seems:
```
execfile("somefile.py", global_vars, local_vars)
```

needs to be changed to:
```
with open("somefile.py") as f:
    code = compile(f.read(), "somefile.py", 'exec')
    exec(code, global_vars, local_vars)
```

This PR makes that change for `parseCustomFile` in `examples/miniedit.py`