### PR TITLE
add unicode = str for python3

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ codecheck: $(PYSRC)
 	-echo "Running code check"
 	util/versioncheck.py
 	pyflakes $(PYSRC)
-	python -m pylint --rcfile=.pylint $(PYSRC)
+	pylint --rcfile=.pylint $(PYSRC)
 #	Exclude miniedit from pep8 checking for now
 	pep8 --repeat --ignore=$(P8IGN) `ls $(PYSRC) | grep -v miniedit.py`
 

--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ codecheck: $(PYSRC)
 	-echo "Running code check"
 	util/versioncheck.py
 	pyflakes $(PYSRC)
-	pylint --rcfile=.pylint $(PYSRC)
+	python -m pylint --rcfile=.pylint $(PYSRC)
 #	Exclude miniedit from pep8 checking for now
 	pep8 --repeat --ignore=$(P8IGN) `ls $(PYSRC) | grep -v miniedit.py`
 

--- a/examples/miniedit.py
+++ b/examples/miniedit.py
@@ -47,7 +47,7 @@ else:
     from tkinter import font as tkFont
     from tkinter import simpledialog as tkSimpleDialog
     from tkinter import filedialog as tkFileDialog
-    unicode = str
+    unicode = str # pylint: disable=redefined-builtin
 # pylint: enable=import-error
 
 import re

--- a/examples/miniedit.py
+++ b/examples/miniedit.py
@@ -47,6 +47,7 @@ else:
     from tkinter import font as tkFont
     from tkinter import simpledialog as tkSimpleDialog
     from tkinter import filedialog as tkFileDialog
+    unicode = str
 # pylint: enable=import-error
 
 import re


### PR DESCRIPTION
# Description
In python3 `unicode` was renamed to `str` and `str` to `bytes`

https://stackoverflow.com/questions/19877306/nameerror-global-name-unicode-is-not-defined-in-python-3

This leads to this error/warning with python3 pyflakes:
```
mininet/examples/miniedit.py:1429: undefined name 'unicode'
```
PR just adds a line `unicode = str` if the python version is 3