### PR TITLE
Fix usage of poll in mininet.utils.errRun

### DIFF
--- a/mininet/test/test_util.py
+++ b/mininet/test/test_util.py
@@ -1,0 +1,39 @@
+#!/usr/bin/env python
+
+"""Package: mininet
+   Test functions defined in mininet.util."""
+
+import unittest
+
+from mininet.util import quietRun
+
+class testQuietRun( unittest.TestCase ):
+    """Test quietRun that runs a command and returns its merged output from
+    STDOUT and STDIN"""
+
+    @staticmethod
+    def getEchoCmd( n ):
+        "Return a command that will print n characters"
+        return "echo -n " + "x" * n
+
+    def testEmpty( self ):
+        "Run a command that prints nothing"
+        output = quietRun(testQuietRun.getEchoCmd( 0 ) )
+        self.assertEqual( 0, len( output ) )
+
+    def testOneRead( self ):
+        """Run a command whose output is entirely read on the first call if
+        each call reads at most 1024 characters
+        """
+        for n in [ 42, 1024 ]:
+            output = quietRun( testQuietRun.getEchoCmd( n ) )
+            self.assertEqual( n, len( output ) )
+
+    def testMultipleReads( self ):
+        "Run a command whose output is not entirely read on the first read"
+        for n in [ 1025, 4242 ]:
+            output = quietRun(testQuietRun.getEchoCmd( n ) )
+            self.assertEqual( n, len( output ) )
+
+if __name__ == "__main__":
+    unittest.main()

--- a/mininet/util.py
+++ b/mininet/util.py
@@ -157,7 +157,7 @@ def errRun( *cmd, **kwargs ):
         for fd, event in readable:
             f = fdToFile[ fd ]
             decoder = fdToDecoder[ fd ]
-            if event & POLLIN:
+            if event & ( POLLIN | POLLHUP ):
                 data = decoder.decode( f.read( 1024 ) )
                 if echo:
                     output( data )
@@ -169,7 +169,7 @@ def errRun( *cmd, **kwargs ):
                     err += data
                     if data == '':
                         errDone = True
-            else:  # POLLHUP or something unexpected
+            else:  # something unexpected
                 if f == popen.stdout:
                     outDone = True
                 elif f == popen.stderr:

--- a/mininet/util.py
+++ b/mininet/util.py
@@ -451,7 +451,7 @@ def pmonitor(popens, timeoutms=500, readline=True,
         fd = popen.stdout.fileno()
         fdToHost[ fd ] = host
         fdToDecoder[ fd ] = getincrementaldecoder()
-        poller.register( fd, POLLIN | POLLHUP )
+        poller.register( fd, POLLIN )
         flags = fcntl( fd, F_GETFL )
         fcntl( fd, F_SETFL, flags | O_NONBLOCK )
     while popens:
@@ -461,7 +461,7 @@ def pmonitor(popens, timeoutms=500, readline=True,
                 host = fdToHost[ fd ]
                 decoder = fdToDecoder[ fd ]
                 popen = popens[ host ]
-                if event & POLLIN or event & POLLHUP:
+                if event & ( POLLIN | POLLHUP ):
                     while True:
                         try:
                             f = popen.stdout


### PR DESCRIPTION
When I used mininet, I encountered the issue that `mininet.util.quietRun` did not work as expected.
It only returned the first 1024 characters of the output.

I found the reason for that in `errRun`: when the poller returns a `POLLHUP`, reading from the file descriptor was stopped.
However, `POLLHUP` does not mean, that we cannot read from the fd any more. Instead, it means that the other side has closed the fd so we cannot write anymore.
[`man-page on poll(3)`](https://linux.die.net/man/3/poll):

> POLLHUP 
The device has been disconnected. This event and POLLOUT are mutually-exclusive; a stream can never be writable if a hangup has occurred. However, this event and POLLIN, POLLRDNORM, POLLRDBAND, or POLLPRI are not mutually-exclusive. This flag is only valid in the revents bitmask; it shall be ignored in the events member. 

Thus, readable data is discarded when stopping on `POLLHUP`. (Also see the [Python docs](https://docs.python.org/3/library/select.html#select.poll.register))

The last sentence in the quote is the reason for the second commit which is merely cosmetic. Only `POLLOUT`, `POLLIN`, `POLLPRI` can be set for registering, other values do not have a meaning, they only can be returned (same for `POLLERR`).

Lastly, I added a unit test that checks if quietRun (that relies on errRun) works as expected.
More unit tests for `mininet.util` could be added there.