### PR TITLE
A couple of simple changes towards a pure Python3 installation

### DIFF
--- a/util/install.sh
+++ b/util/install.sh
@@ -103,7 +103,7 @@ function version_ge {
 }
 
 # Attempt to detect Python version
-PYTHON=${PYTHON:-python}
+PYTHON=${PYTHON:-python3}
 PRINTVERSION='import sys; print(sys.version_info)'
 PYTHON_VERSION=unknown
 for python in $PYTHON python2 python3; do

--- a/util/install.sh
+++ b/util/install.sh
@@ -184,7 +184,7 @@ function mn_deps {
 
     echo "Installing Mininet core"
     pushd $MININET_DIR/mininet
-    sudo PYTHON=${PYTHON} make install
+    sudo make PYTHON=${PYTHON} install
     popd
 }
 

--- a/util/install.sh
+++ b/util/install.sh
@@ -106,7 +106,7 @@ function version_ge {
 PYTHON=${PYTHON:-python3}
 PRINTVERSION='import sys; print(sys.version_info)'
 PYTHON_VERSION=unknown
-for python in $PYTHON python2 python3; do
+for python in $PYTHON python3 python2; do
     if $python -c "$PRINTVERSION" |& grep 'major=2'; then
         PYTHON=$python; PYTHON_VERSION=2; PYPKG=python
         break
@@ -122,6 +122,10 @@ if [ "$PYTHON_VERSION" == unknown ]; then
 fi
 
 echo "Detected Python (${PYTHON}) version ${PYTHON_VERSION}"
+
+function pip {
+	$PYTHON -m pip $*
+}
 
 # Kernel Deb pkg to be removed:
 KERNEL_IMAGE_OLD=linux-image-2.6.26-33-generic
@@ -492,9 +496,9 @@ function ryu {
     cd ryu
 
     # install ryu
-    sudo pip install -r tools/pip-requires -r tools/optional-requires \
+    sudo -H ${PYTHON} -m pip install -r tools/pip-requires -r tools/optional-requires \
         -r tools/test-requires
-    sudo python setup.py install
+    sudo ${PYTHON} setup.py install
 
     # Add symbolic link to /usr/bin
     sudo ln -s ./bin/ryu-manager /usr/local/bin/ryu-manager


### PR DESCRIPTION
These are three simple changes to make python3 win over python when installing mininet.
Installing mininet in Ubuntu20.04 is still a challenge, but I'm working on that