### PR TITLE
fix bug: cannot stop term using 'Mininet.stop()' function

### DIFF
--- a/mininet/term.py
+++ b/mininet/term.py
@@ -56,7 +56,7 @@ def makeTerm( node, title='Node', term='xterm', display=None, cmd='bash'):
         return []
     term = node.popen( cmds[ term ] +
                        [ display, '-e', 'env TERM=ansi %s' % cmd ] )
-    return [ tunnel, term ] if tunnel else [ term ]
+    return [ tunnel, term ] if tunnel else term
 
 def runX11( node, cmd ):
     "Run an X11 client on a node"


### PR DESCRIPTION
Test Code:
```python
from mininet.net import Mininet
from mininet.term import makeTerm

if __name__ == '__main__':
    net = Mininet()
    # other codes
    CLI(net)
    net.stop()
```

I found that if `Mininet.stop()` are called, the opened Xterm windows cannot close. The mininet shows `'list' have not attribute 'gid'`.
I debugged Mininet and found the function `makeTerm()` will not returun a terminal process but a list contains one terminal process object. I fixed this bug and now the terminals can be normally stopped.