### PR TITLE
Added support for KDE Neon

### DIFF
--- a/util/install.sh
+++ b/util/install.sh
@@ -83,6 +83,9 @@ KERNEL_HEADERS=kernel-headers-${KERNEL_NAME}
 # Treat Raspbian as Debian
 [ "$DIST" = 'Raspbian' ] && DIST='Debian'
 
+# Treat KDE Neon as Ubuntu
+[ "$DIST" = 'neon' ] && DIST='Ubuntu'
+
 DISTS='Ubuntu|Debian|Fedora|RedHatEnterpriseServer|SUSE LINUX'
 if ! echo $DIST | egrep "$DISTS" >/dev/null; then
     echo "Install.sh currently only supports $DISTS."


### PR DESCRIPTION
KDE Neon is derived from Ubuntu LTS and so everything is on a 2 year release cycle. However, Plasma on top is rolling release. Because of the way Plasma tends to be developed, rolling Plasma tends to not only be more stable, but you also get all the nice features and bug fixes sooner. So it's safe to treat KDE Neon as Ubuntu.