### PR TITLE
Allow only loss or delay to be set to 0 on TCIntf using config

### DIFF
--- a/mininet/link.py
+++ b/mininet/link.py
@@ -293,7 +293,7 @@ class TCIntf( Intf ):
         else:
             # Delay/jitter/loss/max queue size
             netemargs = '%s%s%s%s' % (
-                'delay %s ' % delay if delay is not None else '',
+                'delay %s ' % delay if (delay is not None and delay > 0) else '',
                 '%s ' % jitter if jitter is not None else '',
                 'loss %.5f ' % loss if (loss is not None and loss > 0) else '',
                 'limit %d' % max_queue_size if max_queue_size is not None
@@ -349,7 +349,7 @@ class TCIntf( Intf ):
 
         # Optimization: return if nothing else to configure
         # Question: what happens if we want to reset things?
-        if ( bw is None and not delay and not loss
+        if ( bw is None and delay is None and loss is None
              and max_queue_size is None ):
             return
 
@@ -359,6 +359,7 @@ class TCIntf( Intf ):
             cmds = [ '%s qdisc del dev %s root' ]
         else:
             cmds = []
+
 
         # Bandwidth limits via various methods
         bwcmds, parent = self.bwCmds( bw=bw, speedup=speedup,


### PR DESCRIPTION
At the moment, the current implementation of TCIntf does not allow you to call config to set loss or delay to 0 without passing other parameters due to how it checks for the presence of arguments. This patch resolves this behavior and removes the need to delete the qdisc manually to remove loss or delay without adding another parameter.