### PR TITLE
Docker & Actions Workflow

### DIFF
--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -18,6 +18,11 @@ jobs:
         shell: bash
         run: echo "##[set-output name=tag;]$(echo ${GITHUB_REF#refs/tags/})"
         id: extract_tag
+      - 
+        name: Extract Repo Owner
+        shell: bash
+        run: echo "##[set-output name=owner;]$(echo ${GITHUB_REPOSITORY%%/*} | tr '[:upper:]' '[:lower:]')"
+        id: extract_owner
       -
         name: Set up QEMU
         uses: docker/setup-qemu-action@v1
@@ -28,8 +33,9 @@ jobs:
         name: Login to DockerHub
         uses: docker/login-action@v1
         with:
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_PASSWORD }}
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.CR_PAT }}
       -
         name: Build and Push
         uses: docker/build-push-action@v2
@@ -38,5 +44,5 @@ jobs:
           file: util/docker/Dockerfile
           platforms: linux/amd64,linux/arm64/v8
           push: true
-          tags: ${{ secrets.DOCKER_USERNAME }}/mininet:${{ steps.extract_tag.outputs.tag }}
+          tags: ghcr.io/${{ steps.extract_owner.outputs.owner }}/mininet:${{ steps.extract_tag.outputs.tag }}
           no-cache: false

--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -1,0 +1,42 @@
+name: Docker Release
+
+on:
+  release:
+    types:
+      - created
+
+jobs:
+  release-docker:
+    name: Build and Publish
+    runs-on: ubuntu-latest
+    steps:
+      - 
+        name: Checkout
+        uses: actions/checkout@v2
+      - 
+        name: Extract Tag Name
+        shell: bash
+        run: echo "##[set-output name=tag;]$(echo ${GITHUB_REF#refs/tags/})"
+        id: extract_tag
+      -
+        name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+      - 
+        name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+      - 
+        name: Login to DockerHub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+      -
+        name: Build and Push
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          file: util/docker/Dockerfile
+          platforms: linux/amd64,linux/arm64/v8
+          push: true
+          tags: ${{ secrets.DOCKER_USERNAME }}/mininet:${{ steps.extract_tag.outputs.tag }}
+          no-cache: false

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,23 +1,18 @@
-name: Docker
+name: Docker Rolling
 
 on:
-  release:
-    types:
-      - created
+  push:
+    branches:
+      - master
 
 jobs:
-  release-docker:
-    name: Release Docker Image
+  rolling-docker:
+    name: Build and Publish
     runs-on: ubuntu-latest
     steps:
       - 
         name: Checkout
         uses: actions/checkout@v2
-      - 
-        name: Extract Tag Name
-        shell: bash
-        run: echo "##[set-output name=tag;]$(echo ${GITHUB_REF#refs/tags/})"
-        id: extract_tag
       -
         name: Set up QEMU
         uses: docker/setup-qemu-action@v1
@@ -31,12 +26,12 @@ jobs:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
       -
-        name: Build and push
+        name: Build and Push
         uses: docker/build-push-action@v2
         with:
           context: .
           file: util/docker/Dockerfile
           platforms: linux/amd64,linux/arm64/v8
           push: true
-          tags: ${{ secrets.DOCKER_USERNAME }}/mininet:${{ steps.extract_tag.outputs.tag }}
+          tags: ${{ secrets.DOCKER_USERNAME }}/mininet:latest
           no-cache: false

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -13,6 +13,11 @@ jobs:
       - 
         name: Checkout
         uses: actions/checkout@v2
+      - 
+        name: Extract Repo Owner
+        shell: bash
+        run: echo "##[set-output name=owner;]$(echo ${GITHUB_REPOSITORY%%/*} | tr '[:upper:]' '[:lower:]')"
+        id: extract_owner
       -
         name: Set up QEMU
         uses: docker/setup-qemu-action@v1
@@ -23,8 +28,9 @@ jobs:
         name: Login to DockerHub
         uses: docker/login-action@v1
         with:
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_PASSWORD }}
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.CR_PAT }}
       -
         name: Build and Push
         uses: docker/build-push-action@v2
@@ -33,5 +39,5 @@ jobs:
           file: util/docker/Dockerfile
           platforms: linux/amd64,linux/arm64/v8
           push: true
-          tags: ${{ secrets.DOCKER_USERNAME }}/mininet:latest
+          tags: ghcr.io/${{ steps.extract_owner.outputs.owner }}/mininet:latest
           no-cache: false

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,42 @@
+name: Docker
+
+on:
+  release:
+    types:
+      - created
+
+jobs:
+  release-docker:
+    name: Release Docker Image
+    runs-on: ubuntu-latest
+    steps:
+      - 
+        name: Checkout
+        uses: actions/checkout@v2
+      - 
+        name: Extract Tag Name
+        shell: bash
+        run: echo "##[set-output name=tag;]$(echo ${GITHUB_REF#refs/tags/})"
+        id: extract_tag
+      -
+        name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+      - 
+        name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+      - 
+        name: Login to DockerHub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+      -
+        name: Build and push
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          file: util/docker/Dockerfile
+          platforms: linux/amd64,linux/arm64/v8
+          push: true
+          tags: ${{ secrets.DOCKER_USERNAME }}/mininet:${{ steps.extract_tag.outputs.tag }}
+          no-cache: false

--- a/INSTALL
+++ b/INSTALL
@@ -174,9 +174,10 @@ like to contribute an installation script, we would welcome it!)
 6. Using Docker
 
      Setting up Mininet as a container is simple, however, does come with 
-     caveats. 
+     caveats. Thus, only use this if you are willing to tackle issues that 
+     may come with your use case.
 
-     Below is an example of how to use the mininet image from Docker Hub.
+     Below is an example of how to use the mininet image from GitHub CR.
      When using, the contents of the MN_FLAGS variable should be populated 
      with any flags you would usually put after the mn command in the cli.
      This will also mount your current working directory to the /shared dir 
@@ -184,12 +185,12 @@ like to contribute an installation script, we would welcome it!)
 
           docker run --rm -it --privileged --network "host" -v $(pwd):/shared \
           -e MN_FLAGS="--controller remote --mac --switch ovsk" \
-          willfantom/mininet:v2.2.2
+          ghcr.io/mininet/mininet:latest
 
-     Building your own image can be done by running th docker build command 
+     Building your own image can be done by running the docker build command 
      from the root mininet directory:
 
-          docker build --rm -f util/docker/Dockerfile -t mininet:v2.2.2 .
+          docker build --rm -f util/docker/Dockerfile -t mininet:local .
 
 Good luck!
 

--- a/INSTALL
+++ b/INSTALL
@@ -171,6 +171,25 @@ like to contribute an installation script, we would welcome it!)
    We encourage contribution of patches to the `install.sh` script to
    support other Linux distributions.
 
+6. Using Docker
+
+     Setting up Mininet as a container is simple, however, does come with 
+     caveats. 
+
+     Below is an example of how to use the mininet image from Docker Hub.
+     When using, the contents of the MN_FLAGS variable should be populated 
+     with any flags you would usually put after the mn command in the cli.
+     This will also mount your current working directory to the /shared dir 
+     within the container.
+
+          docker run --rm -it --privileged --network "host" -v $(pwd):/shared \
+          -e MN_FLAGS="--controller remote --mac --switch ovsk" \
+          willfantom/mininet:v2.2.2
+
+     Building your own image can be done by running th docker build command 
+     from the root mininet directory:
+
+          docker build --rm -f util/docker/Dockerfile -t mininet:v2.2.2 .
 
 Good luck!
 

--- a/util/docker/.dockerignore
+++ b/util/docker/.dockerignore
@@ -1,0 +1,1 @@
+Dockerfile

--- a/util/docker/Dockerfile
+++ b/util/docker/Dockerfile
@@ -1,0 +1,23 @@
+FROM debian:stretch-slim
+
+ENV DEBIAN_FRONTEND=noninteractive
+RUN apt-get update -yq
+RUN apt-get install -yq \
+    arping \
+    git \
+    hping3 \
+    iputils-ping \
+    net-tools \
+    sudo \
+    traceroute
+
+COPY . /root/mininet
+RUN sh -c "/root/mininet/util/install.sh -fnv"
+
+RUN apt-get clean
+
+RUN chmod +x /root/mininet/util/docker/entrypoint.sh
+
+ENV MN_FLAGS="--controller remote --mac --switch ovsk"
+
+ENTRYPOINT [ "sh", "-c", "/root/mininet/util/docker/entrypoint.sh"]

--- a/util/docker/Dockerfile
+++ b/util/docker/Dockerfile
@@ -18,6 +18,6 @@ RUN apt-get clean
 
 RUN chmod +x /root/mininet/util/docker/entrypoint.sh
 
-ENV MN_FLAGS="--controller remote --mac --switch ovsk"
+ENV MN_FLAGS=""
 
 ENTRYPOINT [ "sh", "-c", "/root/mininet/util/docker/entrypoint.sh"]

--- a/util/docker/entrypoint.sh
+++ b/util/docker/entrypoint.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+service openvswitch-switch start
+ovs-vsctl set-manager ptcp:6640
+
+sudo mn -c
+sudo mn $MN_FLAGS
+
+service openvswitch-switch stop


### PR DESCRIPTION
## Docker
Some use cases of Mininet work perfectly well containerised. This adds a simple Dockerfile that creates a container image with Mininet installed. Some other useful packages have also been installed atop the Debian base image. 

A env var `MN_FLAGS` can contain any flags that a user would typically put after the `mn` cli command. This has been documented in `INSTALL`.

## Actions 🚀
With the Dockerfile added, using GitHub Actions to build the images and push them to the GithHub container registry is pretty useful. 2 workflows have been added:
 1. Builds are carried out upon release creation and tagged with the release name (e.g. a release of tag `v.2.2.2` would be tagged as `ghcr.io/mininet/mininet:v.2.2.2`).
 2. Builds are carried out on a push to the `master` branch. These are tagged with `latest` and agin pushed to the GitHub container registry.

The docker images are currently set to be built for `x86_64` and `arm64`.

> A secret `CR_PAT` would be needed in the mininet repo with all package permissions to authorise the ghcr login and push.
