### PR TITLE
Loosen test_intfoptions tolerance to 25% for CI

### DIFF
--- a/examples/test/test_intfoptions.py
+++ b/examples/test/test_intfoptions.py
@@ -13,7 +13,7 @@ class testIntfOptions( unittest.TestCase ):
     def testIntfOptions( self ):
         "verify that intf.config is correctly limiting traffic"
         p = pexpect.spawn( 'python -m mininet.examples.intfoptions ' )
-        tolerance = .2  # plus or minus 20%
+        tolerance = .25  # plus or minus 25% for cloud CI tests
         opts = [ "Results: \['([\d\.]+) .bits/sec",
                  "Results: \['10M', '([\d\.]+) .bits/sec",
                  "h(\d+)->h(\d+): (\d)/(\d),"
@@ -30,8 +30,10 @@ class testIntfOptions( unittest.TestCase ):
                 BW = 10
                 measuredBw = float( p.match.group( 1 ) )
                 loss = ( measuredBw / BW ) * 100
-                self.assertGreaterEqual( loss, 50 * ( 1 - tolerance ) )
-                self.assertLessEqual( loss,  50 * ( 1 + tolerance ) )
+                self.assertGreaterEqual( loss, 50 * ( 1 - tolerance ),
+                                         'loss of %d%% << 50%%' % loss )
+                self.assertLessEqual( loss,  50 * ( 1 + tolerance ),
+                                      'loss of %d%% >> 50%%' % loss  )
             elif index == 2:
                 delay = float( p.match.group( 6 ) )
                 self.assertGreaterEqual( delay, 15 * ( 1 - tolerance ) )


### PR DESCRIPTION
Adjusting the tolerance for this test to compensate
for apparent performance variation when running as
part of github actions CI builds/tests.