### PR TITLE
Wait for exit to avoid leftover dp0

### DIFF
--- a/examples/test/test_scratchnet.py
+++ b/examples/test/test_scratchnet.py
@@ -16,6 +16,7 @@ class testScratchNet( unittest.TestCase ):
         p = pexpect.spawn( 'python -m %s' % name )
         index = p.expect( self.opts, timeout=120 )
         self.assertEqual( index, 0 )
+        p.wait()
 
     def testPingKernel( self ):
         self.pingTest( 'mininet.examples.scratchnet' )


### PR DESCRIPTION
In certain cases, dp0 and its interfaces were not
being cleaned up, probably due to scratchnet.py being
killed before it terminated. This in turn caused the
natnet test to fail.