### PR TITLE
Install python3 mn last in install-mininet-vm.sh

### DIFF
--- a/bin/mn
+++ b/bin/mn
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python
 
 """
 Mininet runner

--- a/util/vm/install-mininet-vm.sh
+++ b/util/vm/install-mininet-vm.sh
@@ -36,11 +36,10 @@ fi
 # Install Mininet for Python2 and Python3
 APT="sudo apt-get -y -qq"
 $APT install python3
-$APT install python-is-python3 || true
 $APT install python2 || $APT install python
-python --version
-time PYTHON=python3 mininet/util/install.sh
+python --version || $APT install python-is-python3
 time PYTHON=python2 mininet/util/install.sh -n
+time PYTHON=python3 mininet/util/install.sh
 # Finalize VM
 time mininet/util/install.sh -tcd
 # Ignoring this since NOX classic is deprecated


### PR DESCRIPTION
This means that 'mn' will run be default in python3.

For python2, run

    sudo python2 `which mn`

Also:

- change mn execution line to /usr/bin/python
  (install seems to change it to python2 or python3)

- don't install python-is-python3 package