### PR TITLE
Use /usr/bin/env python for virtualenv

### DIFF
--- a/bin/mn
+++ b/bin/mn
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 """
 Mininet runner

--- a/examples/baresshd.py
+++ b/examples/baresshd.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 "This example doesn't use OpenFlow, but attempts to run sshd in a namespace."
 

--- a/examples/bind.py
+++ b/examples/bind.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 """
 bind.py: Bind mount example

--- a/examples/cluster.py
+++ b/examples/cluster.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 """
 cluster.py: prototyping/experimentation for distributed Mininet,

--- a/examples/clustercli.py
+++ b/examples/clustercli.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 "CLI for Mininet Cluster Edition prototype demo"
 

--- a/examples/clusterdemo.py
+++ b/examples/clusterdemo.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 "clusterdemo.py: demo of Mininet Cluster Edition prototype"
 

--- a/examples/clusterperf.py
+++ b/examples/clusterperf.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 "clusterperf.py compare the maximum throughput between SSH and GRE tunnels"
 

--- a/examples/consoles.py
+++ b/examples/consoles.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 """
 consoles.py: bring up a bunch of miniature consoles on a virtual network

--- a/examples/controllers.py
+++ b/examples/controllers.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 """
 Create a network where different switches are connected to

--- a/examples/controllers2.py
+++ b/examples/controllers2.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 """
 This example creates a multi-controller network from semi-scratch by

--- a/examples/controlnet.py
+++ b/examples/controlnet.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 """
 controlnet.py: Mininet with a custom control network

--- a/examples/cpu.py
+++ b/examples/cpu.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 """
 cpu.py: test iperf bandwidth for varying cpu limits

--- a/examples/emptynet.py
+++ b/examples/emptynet.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 """
 This example shows how to create an empty Mininet object

--- a/examples/hwintf.py
+++ b/examples/hwintf.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 """
 This example shows how to add an interface (for example a real

--- a/examples/intfoptions.py
+++ b/examples/intfoptions.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 '''
 example of using various TCIntf options.

--- a/examples/limit.py
+++ b/examples/limit.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 """
 limit.py: example of using link and CPU limits

--- a/examples/linearbandwidth.py
+++ b/examples/linearbandwidth.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 """
 Test bandwidth (using iperf) on linear networks of varying size,

--- a/examples/linuxrouter.py
+++ b/examples/linuxrouter.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 """
 linuxrouter.py: Example network with Linux IP router

--- a/examples/miniedit.py
+++ b/examples/miniedit.py
@@ -1704,7 +1704,7 @@ class MiniEdit( Frame ):
             # debug( "Now saving under %s\n" % fileName )
             f = open(fileName, 'wb')
 
-            f.write("#!/usr/bin/python\n")
+            f.write("#!/usr/bin/env python\n")
             f.write("\n")
             f.write("from mininet.net import Mininet\n")
             f.write("from mininet.node import Controller, RemoteController, OVSController\n")

--- a/examples/mobility.py
+++ b/examples/mobility.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 """
 Simple example of Mobility with Mininet

--- a/examples/multilink.py
+++ b/examples/multilink.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 """
 This is a simple example that demonstrates multiple links

--- a/examples/multiping.py
+++ b/examples/multiping.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 """
 multiping.py: monitor multiple sets of hosts using ping

--- a/examples/multipoll.py
+++ b/examples/multipoll.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 """
 Simple example of sending output to multiple files and

--- a/examples/multitest.py
+++ b/examples/multitest.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 """
 This example shows how to create a network and run multiple tests.

--- a/examples/nat.py
+++ b/examples/nat.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 """
 Example to create a Mininet topology and connect it to the internet via NAT

--- a/examples/natnet.py
+++ b/examples/natnet.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 """
 natnet.py: Example network with NATs

--- a/examples/numberedports.py
+++ b/examples/numberedports.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 """
 Create a network with 5 hosts, numbered 1-4 and 9.

--- a/examples/popen.py
+++ b/examples/popen.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 """
 This example monitors a number of hosts using host.popen() and

--- a/examples/popenpoll.py
+++ b/examples/popenpoll.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 "Monitor multiple hosts using popen()/pmonitor()"
 

--- a/examples/scratchnet.py
+++ b/examples/scratchnet.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 """
 Build a simple network from scratch, using mininet primitives.

--- a/examples/scratchnetuser.py
+++ b/examples/scratchnetuser.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 """
 Build a simple network from scratch, using mininet primitives.

--- a/examples/simpleperf.py
+++ b/examples/simpleperf.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 """
 Simple example of setting network and CPU parameters

--- a/examples/sshd.py
+++ b/examples/sshd.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 """
 Create a network and start sshd(8) on each host.

--- a/examples/tree1024.py
+++ b/examples/tree1024.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 """
 Create a 1024-host network, and run the CLI on it.

--- a/examples/treeping64.py
+++ b/examples/treeping64.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 "Create a 64-node tree network, and test connectivity using ping."
 

--- a/util/doxify.py
+++ b/util/doxify.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 
 """
 Convert simple documentation to epydoc/pydoctor-compatible markup
@@ -83,7 +83,3 @@ if __name__ == '__main__':
     infile.close()
     os.close( outfid )
     call( [ 'doxypy', outname ] )
-
-
-
-

--- a/util/unpep8
+++ b/util/unpep8
@@ -1,7 +1,7 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 
 """
-Translate from PEP8 Python style to Mininet (i.e. Arista-like) 
+Translate from PEP8 Python style to Mininet (i.e. Arista-like)
 Python style
 
 usage: unpep8 < old.py > new.py
@@ -51,7 +51,7 @@ def fixUnderscoreTriplet( match ):
 def reinstateCapWords( text ):
    underscoreTriplet = re.compile( r'[A-Za-z0-9]_[A-Za-z0-9]' )
    return underscoreTriplet.sub( fixUnderscoreTriplet, text )
- 
+
 def replaceTripleApostrophes( text ):
    "Replace triple apostrophes with triple quotes."
    return text.replace( "'''", '"""')
@@ -60,7 +60,7 @@ def simplifyTripleQuotes( text ):
    "Fix single-line doc strings."
    r = re.compile( r'"""([^\"\n]+)"""' )
    return r.sub( r'"\1"', text )
-   
+
 def insertExtraSpaces( text ):
    "Insert extra spaces inside of parentheses and brackets/curly braces."
    lparen = re.compile( r'\((?![\s\)])' )
@@ -76,9 +76,9 @@ def insertExtraSpaces( text ):
    lcurly = re.compile( r'\{(?![\s\}])' )
    text = lcurly.sub( r'{ ', text )
    rcurly = re.compile( r'([^\s\{])(?=\})' )
-   text = rcurly.sub( r'\1 ', text)   
+   text = rcurly.sub( r'\1 ', text)
    return text
-   
+
 def fixDoxygen( text ):
    """Translate @param foo to foo:, @return bar to returns: bar, and
       @author me to author: me"""
@@ -96,11 +96,11 @@ def removeCommentFirstBlankLine( text ):
    "Remove annoying blank lines after first line in comments."
    line = re.compile( r'("""[^\n]*\n)\s*\n', re.MULTILINE )
    return line.sub( r'\1', text )
-   
+
 def fixArgs( match, kwarg = re.compile( r'(\w+) = ' ) ):
    "Replace foo = bar with foo=bar."
    return kwarg.sub( r'\1=', match.group() )
-   
+
 def fixKeywords( text ):
    "Change keyword argumentsfrom foo = bar to foo=bar."
    args = re.compile( r'\(([^\)]+)\)', re.MULTILINE )
@@ -115,7 +115,7 @@ def fixKeywords( text ):
 def lineIter( text ):
    "Simple iterator over lines in text."
    for line in text.splitlines(): yield line
-   
+
 def stringIter( strList ):
    "Yield strings in strList."
    for s in strList: yield s
@@ -134,7 +134,7 @@ def restoreRegex( regex, old, new ):
 # This is a cheap hack, and it may not work 100%, since
 # it doesn't handle multiline strings.
 # However, it should be mostly harmless...
-   
+
 def restoreStrings( oldText, newText ):
    "Restore strings from oldText into newText, returning result."
    oldLines, newLines = lineIter( oldText ), lineIter( newText )
@@ -149,13 +149,13 @@ def restoreStrings( oldText, newText ):
       newLine = restoreRegex( tickStrings, oldLine, newLine )
       result += newLine + '\n'
    return result
-   
+
 # This might be slightly controversial, since it uses
 # three spaces to line up multiline comments. However,
 # I much prefer it. Limitations: if you have deeper
 # indents in comments, they will be eliminated. ;-(
 
-def fixComment( match, 
+def fixComment( match,
    indentExp=re.compile( r'\n([ ]*)(?=[^/s])', re.MULTILINE ),
    trailingQuotes=re.compile( r'\s+"""' ) ):
    "Re-indent comment, and join trailing quotes."
@@ -166,17 +166,17 @@ def fixComment( match,
    if len( originalIndent ) is not 0: indent += '   '
    comment = indentExp.sub( indent, comment )
    return originalIndent + trailingQuotes.sub( '"""', comment )
-   
+
 def fixCommentIndents( text ):
    "Fix multiline comment indentation."
    comments = re.compile( r'^([ ]*)("""[^"]*""")$', re.MULTILINE )
    return comments.sub( fixComment, text )
- 
+
 def removeBogusLinefeeds( text ):
    "Remove extra linefeeds at the end of single-line comments."
    bogusLfs = re.compile( r'"([^"\n]*)\n"', re.MULTILINE )
    return bogusLfs.sub( '"\1"', text)
-   
+
 def convertFromPep8( program ):
    oldProgram = program
    # Program text transforms

--- a/util/versioncheck.py
+++ b/util/versioncheck.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 from subprocess import check_output as co
 from sys import exit, version_info

--- a/util/vm/build.py
+++ b/util/vm/build.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python2.7
+#!/usr/bin/python2
 
 """
 build.py: build a Mininet VM


### PR DESCRIPTION
This helps with virtualenv although it can open
up another security hole if you end up using an
unexpected python interpreter.

Overall it seems to make sense to err on the side
of usability but it's good to be aware of security.

However, for the remaining utility scripts that require
python 2, we explicitly note this with #!/usr/bin/python2.