### PR TITLE
Fix ryu

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -56,7 +56,7 @@ install-manpages: $(MANPAGES)
 	install -D -t $(MANDIR) $(MANPAGES)
 
 install: install-mnexec install-manpages
-	$(PYTHON) -m pip install .
+	$(PYTHON) -m pip install . --upgrade --force-reinstall
 
 develop: $(MNEXEC) $(MANPAGES)
 # 	Perhaps we should link these as well

--- a/Makefile
+++ b/Makefile
@@ -56,7 +56,7 @@ install-manpages: $(MANPAGES)
 	install -D -t $(MANDIR) $(MANPAGES)
 
 install: install-mnexec install-manpages
-	$(PYTHON) -m pip install . --upgrade --force-reinstall
+	$(PYTHON) -m pip install .
 
 develop: $(MNEXEC) $(MANPAGES)
 # 	Perhaps we should link these as well

--- a/mininet/node.py
+++ b/mininet/node.py
@@ -1505,32 +1505,26 @@ class NOX( Controller ):
 
         Controller.__init__( self, name,
                              command=noxCoreDir + '/nox_core',
-                             cargs='--libdir=/usr/local/lib -v -i ptcp:%s ' +
+                             cargs='--libdir=/usr/local/lib -v '
+                             '-i ptcp:%s ' +
                              ' '.join( noxArgs ),
                              cdir=noxCoreDir,
                              **kwargs )
 
 class Ryu( Controller ):
-    "Controller to run Ryu application"
-    def __init__( self, name, *ryuArgs, **kwargs ):
+    "Ryu OpenFlow Controller"
+    def __init__( self, name, ryuArgs='ryu.app.simple_switch',
+                  command='ryu run', **kwargs ):
         """Init.
-        name: name to give controller.
-        ryuArgs: arguments and modules to pass to Ryu"""
-        homeDir = quietRun( 'printenv HOME' ).strip( '\r\n' )
-        ryuCoreDir = '%s/ryu/ryu/app/' % homeDir
-        if not ryuArgs:
-            warn( 'warning: no Ryu modules specified; '
-                  'running simple_switch only\n' )
-            ryuArgs = [ ryuCoreDir + 'simple_switch.py' ]
-        elif not isinstance( ryuArgs, ( list, tuple ) ):
-            ryuArgs = [ ryuArgs ]
-
-        Controller.__init__( self, name,
-                             command='ryu-manager',
-                             cargs='--ofp-tcp-listen-port %s ' +
-                             ' '.join( ryuArgs ),
-                             cdir=ryuCoreDir,
-                             **kwargs )
+           name: name to give controller.
+           ryuArgs: modules to pass to Ryu (ryu.app.simple_switch)
+           command: comand to run Ryu ('ryu run')"""
+        if isinstance( ryuArgs, ( list, tuple ) ):
+            ryuArgs = ' '.join( ryuArgs )
+        cargs = kwargs.pop(
+            'cargs', ryuArgs + ' --ofp-tcp-listen-port %s' )
+        Controller.__init__( self, name, command=command,
+                             cargs=cargs, **kwargs )
 
 
 class RemoteController( Controller ):


### PR DESCRIPTION
 Simplify RyuController and update for current Ryu
    
    Notes:
    
    The Ryu() constructor has changed slightly. We still add
    `--ofp-tcp-listen-port %s` to the end of `cargs` to make
    Controller() happy.
    
    `command` is now `ryu run` so it includes the `run` command
    but can be specified explicitly as needed.
    
    You should be able to run Ryu's simple_switch by using:
    
        mn --controller ryu
    
    and pass alternate modules such as simple_switch_13:
    
        mn --controller ryu,ryu.app.simple_switch_13
    
    Unfortunately simple_switch_stp seems like it may be broken
    for Python 3.8, which is too bad because we'd like to test
    the Torus topo with it.
