### PR TITLE
Make mn -w wait indefinitely and add --twait option

### DIFF
--- a/bin/mn
+++ b/bin/mn
@@ -290,6 +290,9 @@ class MininetRunner( object ):
                          help='prints the version and exits' )
         opts.add_option( '--wait', '-w', action='store_true',
                          default=False, help='wait for switches to connect' )
+        opts.add_option( '--twait', '-t', action='store', type='int',
+                         dest='wait',
+                         help='timed wait (s) for switches to connect' )
         opts.add_option( '--cluster', type='string', default=None,
                          metavar='server1,server2...',
                          help=( 'run on multiple servers (experimental!)' ) )

--- a/mininet/net.py
+++ b/mininet/net.py
@@ -137,7 +137,9 @@ class Mininet( object ):
            autoStaticArp: set all-pairs static MAC addrs?
            autoPinCpus: pin hosts to (real) cores (requires CPULimitedHost)?
            listenPort: base listening port to open; will be incremented for
-               each additional switch in the net if inNamespace=False"""
+               each additional switch in the net if inNamespace=False
+           waitConnected: wait for switches to Connect?
+               (False; True/None=wait indefinitely; time(s)=timed wait)"""
         self.topo = topo
         self.switch = switch
         self.host = host
@@ -175,10 +177,9 @@ class Mininet( object ):
         if topo and build:
             self.build()
 
-    def waitConnected( self, timeout=5, delay=.5 ):
-        """wait for each switch to connect to a controller,
-           up to 5 seconds
-           timeout: time to wait, or None to wait indefinitely
+    def waitConnected( self, timeout=None, delay=.5 ):
+        """wait for each switch to connect to a controller
+           timeout: time to wait, or None or True to wait indefinitely
            delay: seconds to sleep per iteration
            returns: True if all switches are connected"""
         info( '*** Waiting for switches to connect\n' )
@@ -192,7 +193,8 @@ class Mininet( object ):
             if not remaining:
                 info( '\n' )
                 return True
-            if timeout is not None and time > timeout:
+            # Still allow None to preserve 2.2 behavior
+            if timeout not in ( None, True ) and time > timeout:
                 break
             sleep( delay )
             time += delay


### PR DESCRIPTION
Background: In Mininet 2.2, waitConnected() waits forever
by default. We are going to preserve this behavior for 2.3.

Therefore, the --wait/-w option will wait forever. This is used
in the tests to make sure that all switches have connected to
their controllers.

A new --twait/-t <int> option has been added for timed waits.

The API for Mininet(....waitConnected=False/True) is preserved,
but you can now pass in an integer wait time. False means
do not wait at all. True means wait forever. I have elected
for now to preserve None also meaning wait forever as it was
in 2.2, but note that you should probably use the boolean
True/False instead.