### PR TITLE
fix --twait

### DIFF
--- a/bin/mn
+++ b/bin/mn
@@ -101,7 +101,6 @@ CLI = None  # Set below if needed
 # Locally defined tests
 def allTest( net ):
     "Run ping and iperf tests"
-    net.waitConnected()
     net.start()
     net.ping()
     net.iperf()
@@ -131,7 +130,6 @@ def runTests( mn, options ):
             if callable( testfn ):
                 testfn( mn, *args, **kwargs )
             elif hasattr( mn, test ):
-                mn.waitConnected()
                 getattr( mn, test )( *args, **kwargs )
             else:
                 raise Exception( 'Test %s is unknown - please specify one of '
@@ -388,6 +386,11 @@ class MininetRunner( object ):
             Net = partial( MininetCluster, servers=servers,
                            placement=PLACEMENT[ opts.placement ] )
             mininet.cli.CLI = ClusterCLI
+
+        # Wait for controllers to connect unless we're running null test
+        if ( opts.test and opts.test != [ 'none' ] and
+             isinstance( opts.wait, bool ) ):
+            opts.wait = True
 
         mn = Net( topo=topo,
                   switch=switch, host=host, controller=controller, link=link,

--- a/mininet/net.py
+++ b/mininet/net.py
@@ -183,8 +183,11 @@ class Mininet( object ):
            delay: seconds to sleep per iteration
            returns: True if all switches are connected"""
         info( '*** Waiting for switches to connect\n' )
-        time = 0
+        time = 0.0
         remaining = list( self.switches )
+        # False: 0s timeout; None: wait forever (preserve 2.2 behavior)
+        if isinstance( timeout, bool ):
+            timeout = None if timeout else 0
         while True:
             for switch in tuple( remaining ):
                 if switch.connected():
@@ -193,8 +196,7 @@ class Mininet( object ):
             if not remaining:
                 info( '\n' )
                 return True
-            # Still allow None to preserve 2.2 behavior
-            if timeout not in ( None, True ) and time > timeout:
+            if timeout is not None and time >= timeout:
                 break
             sleep( delay )
             time += delay
@@ -561,7 +563,7 @@ class Mininet( object ):
                 started.update( { s: s for s in success } )
         info( '\n' )
         if self.waitConn:
-            self.waitConnected()
+            self.waitConnected( self.waitConn )
 
     def stop( self ):
         "Stop the controller(s), switches and hosts"


### PR DESCRIPTION
- pass timeout correctly to waitConnected()
- handle surprising behavior that 1 == True in Python