### PR TITLE
Fix python3 compatibility issues in miniedit

### DIFF
--- a/examples/miniedit.py
+++ b/examples/miniedit.py
@@ -1449,7 +1449,7 @@ class MiniEdit( Frame ):
 
         # Load application preferences
         if 'application' in loadedTopology:
-            self.appPrefs = dict(self.appPrefs.items() + loadedTopology['application'].items())
+            self.appPrefs.update(loadedTopology['application'])
             if "ovsOf10" not in self.appPrefs["openFlowVersions"]:
                 self.appPrefs["openFlowVersions"]["ovsOf10"] = '0'
             if "ovsOf11" not in self.appPrefs["openFlowVersions"]:
@@ -1683,7 +1683,7 @@ class MiniEdit( Frame ):
             savingDictionary['application'] = self.appPrefs
 
             try:
-                f = open(fileName, 'wb')
+                f = open(fileName, 'w')
                 f.write(json.dumps(savingDictionary, sort_keys=True, indent=4, separators=(',', ': ')))
             # pylint: disable=broad-except
             except Exception as er:
@@ -1702,7 +1702,7 @@ class MiniEdit( Frame ):
         fileName = tkFileDialog.asksaveasfilename(filetypes=myFormats ,title="Export the topology as...")
         if len(fileName ) > 0:
             # debug( "Now saving under %s\n" % fileName )
-            f = open(fileName, 'wb')
+            f = open(fileName, 'w')
 
             f.write("#!/usr/bin/env python\n")
             f.write("\n")


### PR DESCRIPTION
`dict.items()` returns a list in python2 and a dict_items in python3. dict_items can't be added with `+`, which caused failures when using python3. This update changes this to `dict.update()` which works in both python2 and python3.

When files are opened with `f = open(filename, "wb")`, the following calls to `f.write` expects bytes while miniedit provides regular strings. This works fine in python2, as python2 strings are bytes. This changed in python3, which caused miniedit to fail when saving files. This update changes the call to `open()` to use text-mode, which makes it possible to write strings regardless of python version.

Fixes #1054 and #1049 