### PR TITLE
Update install.sh to remove error while installing in containers behind squid proxy (cache)

### DIFF
--- a/util/install.sh
+++ b/util/install.sh
@@ -231,7 +231,7 @@ function of {
     fi
     # was: git clone git://openflowswitch.org/openflow.git
     # Use our own fork on github for now:
-    git clone git://github.com/mininet/openflow
+    git clone http://github.com/mininet/openflow
     cd $BUILD_DIR/openflow
 
     # Patch controller to handle more than 16 switches
@@ -498,7 +498,7 @@ function ivs {
 
     # Install IVS from source
     cd $BUILD_DIR
-    git clone git://github.com/floodlight/ivs $IVS_SRC
+    git clone http://github.com/floodlight/ivs $IVS_SRC
     cd $IVS_SRC
     git submodule update --init
     make
@@ -518,7 +518,7 @@ function ryu {
 
     # fetch RYU
     cd $BUILD_DIR/
-    git clone git://github.com/osrg/ryu.git ryu
+    git clone http://github.com/osrg/ryu.git ryu
     cd ryu
 
     # install ryu
@@ -629,7 +629,7 @@ function oftest {
 
     # Install oftest:
     cd $BUILD_DIR/
-    git clone git://github.com/floodlight/oftest
+    git clone http://github.com/floodlight/oftest
 }
 
 # Install cbench
@@ -646,7 +646,7 @@ function cbench {
     cd $BUILD_DIR/
     # was:  git clone git://gitosis.stanford.edu/oflops.git
     # Use our own fork on github for now:
-    git clone git://github.com/mininet/oflops
+    git clone http://github.com/mininet/oflops
     cd oflops
     sh boot.sh || true # possible error in autoreconf, so run twice
     sh boot.sh


### PR DESCRIPTION
change git:// to http:// for git clone commands. Two reasons:
1. git clone git:// gives error "fatal: unable to look up github.com (port 9418) (Temporary failure in name resolution)" while installing inside containers behind squid proxy (cache). renaming git:// to http:// solves it.
2. http allows to cache. https doesnot. There is only need for checking tampering of received files.