### PR TITLE
get-pip

### DIFF
--- a/util/install.sh
+++ b/util/install.sh
@@ -187,7 +187,7 @@ function mn_deps {
         $install ${PYPKG}-pip || $install ${PYPKG}-pip-whl
         if ! ${PYTHON} -m pip -V; then
             if [ $PYTHON_VERSION == 2 ]; then
-                wget https://bootstrap.pypa.io/2.6/get-pip.py
+                wget https://bootstrap.pypa.io/pip/2.6/get-pip.py
             else
                 wget https://bootstrap.pypa.io/get-pip.py
             fi


### PR DESCRIPTION
The URL of get-pip.py has changed to https://bootstrap.pypa.io/pip/2.6/get-pip.py