### PR TITLE
Remove the wrong link and update it.

### DIFF
--- a/util/install.sh
+++ b/util/install.sh
@@ -187,7 +187,7 @@ function mn_deps {
         $install ${PYPKG}-pip || $install ${PYPKG}-pip-whl
         if ! ${PYTHON} -m pip -V; then
             if [ $PYTHON_VERSION == 2 ]; then
-                wget https://bootstrap.pypa.io/2.6/get-pip.py
+                wget https://bootstrap.pypa.io/pip/2.7/get-pip.py
             else
                 wget https://bootstrap.pypa.io/get-pip.py
             fi


### PR DESCRIPTION
The original link has expired, it shows "404 Not Found".