### PR TITLE
Call ping with LANG=C to avoid erros parsing localised ping output

### DIFF
--- a/mininet/net.py
+++ b/mininet/net.py
@@ -671,7 +671,7 @@ class Mininet( object ):
                     if timeout:
                         opts = '-W %s' % timeout
                     if dest.intfs:
-                        result = node.cmd( 'ping -c1 %s %s' %
+                        result = node.cmd( 'LANG=C ping -c1 %s %s' %
                                            (opts, dest.IP()) )
                         sent, received = self._parsePing( result )
                     else:


### PR DESCRIPTION
Fixes: #1063

mininet/net.py _parsePingFull() relays on a ping output in English. This patch forces the call to ping with LANG=C to avoid issues when parsing localised output strings.