### PR TITLE
Remove ubuntu-16.04 from run-tests.yaml

### DIFF
--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-20.04, ubuntu-18.04, ubuntu-16.04]
+        os: [ubuntu-20.04, ubuntu-18.04]
         python-version: [3.x, 2.x]
     steps:
       - name: Check out Mininet source


### PR DESCRIPTION
GitHub seems to have pulled the plug on 16.04 VMs for
Actions, and this is breaking our integration.

Ideally we should come up with another test method
for 16.04 (notably the 16.04 kernel) as well as
other distros that Actions doesn't support
directly such as Debian.