### PR TITLE
install.sh : HTTPS url to SSH addr.

### DIFF
--- a/util/install.sh
+++ b/util/install.sh
@@ -616,7 +616,7 @@ function nox13 {
 function pox {
     echo "Installing POX into $BUILD_DIR/pox..."
     cd $BUILD_DIR
-    git clone https://github.com/noxrepo/pox.git
+    git clone git@github.com:noxrepo/pox.git
 }
 
 # Install OFtest


### PR DESCRIPTION
I replace the only HTTPS url to SSH addr in install.sh.

It's strongly recommended to do so, for in github-censored country, visiting/connecting to github.com is blocked. This tiny change could potentially improve developers' install experience of mininet. 