### PR TITLE
Remove unencrypted git protocol use, as it will be disabled march 15th

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -51,7 +51,7 @@ like to contribute an installation script, we would welcome it!)
    If you're reading this, you've probably already done so, but the
    command to download the Mininet source code is:
 
-        git clone git://github.com/mininet/mininet.git
+        git clone https://github.com/mininet/mininet.git
 
    Note that the above git command will check out the latest and greatest
    Mininet (which we recommend!) If you want to run the last
@@ -147,7 +147,7 @@ like to contribute an installation script, we would welcome it!)
 
     * clone the Mininet repository
 
-        git clone git://github.com/mininet/mininet.git
+        git clone https://github.com/mininet/mininet.git
 
     * install Mininet, the OpenFlow reference implementation, and
       Open vSwitch

--- a/util/install.sh
+++ b/util/install.sh
@@ -231,7 +231,7 @@ function of {
     fi
     # was: git clone git://openflowswitch.org/openflow.git
     # Use our own fork on github for now:
-    git clone git://github.com/mininet/openflow
+    git clone https://github.com/mininet/openflow
     cd $BUILD_DIR/openflow
 
     # Patch controller to handle more than 16 switches
@@ -498,7 +498,7 @@ function ivs {
 
     # Install IVS from source
     cd $BUILD_DIR
-    git clone git://github.com/floodlight/ivs $IVS_SRC
+    git clone https://github.com/floodlight/ivs $IVS_SRC
     cd $IVS_SRC
     git submodule update --init
     make
@@ -518,7 +518,7 @@ function ryu {
 
     # fetch RYU
     cd $BUILD_DIR/
-    git clone git://github.com/osrg/ryu.git ryu
+    git clone https://github.com/osrg/ryu.git ryu
     cd ryu
 
     # install ryu
@@ -629,7 +629,7 @@ function oftest {
 
     # Install oftest:
     cd $BUILD_DIR/
-    git clone git://github.com/floodlight/oftest
+    git clone https://github.com/floodlight/oftest
 }
 
 # Install cbench
@@ -646,7 +646,7 @@ function cbench {
     cd $BUILD_DIR/
     # was:  git clone git://gitosis.stanford.edu/oflops.git
     # Use our own fork on github for now:
-    git clone git://github.com/mininet/oflops
+    git clone https://github.com/mininet/oflops
     cd oflops
     sh boot.sh || true # possible error in autoreconf, so run twice
     sh boot.sh

--- a/util/vm/install-mininet-vm.sh
+++ b/util/vm/install-mininet-vm.sh
@@ -25,7 +25,7 @@ if [ -e /etc/rc.local.backup ]; then
 fi
 # Fetch Mininet
 sudo apt-get -y -qq install git-core openssh-server
-git clone git://github.com/mininet/mininet
+git clone https://github.com/mininet/mininet
 # Optionally check out branch
 if [ "$1" != "" ]; then
     pushd mininet


### PR DESCRIPTION
Hi,

I just got hit by GitHub's current brownout of unencrypted git protocol usage when trying to install Mininet from source. 

As usage of the unencrypted git protocol will be retired permanently on March 15th, I am submitting this patch changing the URLs to https instead.

For details, please see https://github.blog/2021-09-01-improving-git-protocol-security-github/

Cheers :)
Andreas