### PR TITLE
Transforms the ISSUE_TEMPLATE disclaimer into a comment

### DIFF
--- a/.github/ISSUE_TEMPLATE
+++ b/.github/ISSUE_TEMPLATE
@@ -1,4 +1,5 @@
-**Mininet uses GitHub issues for bug reports and feature requests only.**
+<!--
+Mininet uses GitHub issues for bug reports and feature requests only.
 These issues can be viewed at bugs.mininet.org
 
 If you have a question that is not a **bug report** or a **feature request**,
@@ -8,7 +9,7 @@ at faq.mininet.org, and the mininet-discuss mailing list.
 For bug reports, please fill in the following information in detail,
 and also feel free to include additional information such as debug
 output from mn -v debug, etc.
---- Cut Here ---
+-->
 ### Expected/Desired Behavior:
 
 ### Actual Behavior:


### PR DESCRIPTION
I've seen so many issues in the past days that didn't remove the disclaimer on top and it kinda annoys me personally ;)