### PR TITLE
Add support for Debian Bullseye to the setup script

### DIFF
--- a/util/install.sh
+++ b/util/install.sh
@@ -174,13 +174,22 @@ function mn_deps {
                         python-pep8 ${PYPKG}-pexpect ${PYPKG}-tk
     else  # Debian/Ubuntu
         pf=pyflakes
+        pep8=pep8
         # Starting around 20.04, installing pyflakes instead of pyflakes3
         # causes Python 2 to be installed, which is exactly NOT what we want.
-        if [ `expr $RELEASE '>=' 20.04` = "1" ]; then
+        if [ "$DIST" = "Ubuntu" -a `expr $RELEASE '>=' 20.04` = "1" ]; then
                 pf=pyflakes3
         fi
+        # Debian 11 "bullseye" renamed 
+        # * pep8 to python3-pep8
+        # * pyflakes to pyflakes3
+        if [ "$DIST" = "Debian" -a `expr $RELEASE '>=' 11` = "1" ]; then
+                pf=pyflakes3
+                pep8=python3-pep8
+        fi
+
         $install gcc make socat psmisc xterm ssh iperf telnet \
-                 ethtool help2man $pf pylint pep8 \
+                 ethtool help2man $pf pylint $pep8 \
                  net-tools \
                  ${PYPKG}-pexpect ${PYPKG}-tk
         # Install pip


### PR DESCRIPTION
Running the current install script on Debian 11 Bullseye fails with

```
Installing Mininet dependencies

[...]

E: Package 'pyflakes' has no installation candidate
E: Package 'pep8' has no installation candidate
```

This PR patches the installer to choose the renamed packages on Debian versions >= 11.