### PR TITLE
Update LICENSE to standard BSD 3-clause license text

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,33 +1,29 @@
-Mininet 2.3.1b1 License
+BSD 3-Clause License (original Mininet authors: Bob Lantz and Brandon Heller)
 
-Copyright (c) 2013-2021 Open Networking Foundation
-Copyright (c) 2009-2012 Bob Lantz and The Board of Trustees of
-The Leland Stanford Junior University
+Copyright (c) 2013-2022 Open Networking Foundation
+Copyright (c) 2009-2012 Bob Lantz and The Board of Trustees of The Leland Stanford Junior University
 
-Original authors: Bob Lantz and Brandon Heller
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
 
-We are making Mininet available for public use and benefit with the
-expectation that others will use, modify and enhance the Software and
-contribute those enhancements back to the community. However, since we
-would like to make the Software available for broadest use, with as few
-restrictions as possible permission is hereby granted, free of charge, to
-any person obtaining a copy of this Software to deal in the Software
-under the copyrights without restriction, including without limitation
-the rights to use, copy, modify, merge, publish, distribute, sublicense,
-and/or sell copies of the Software, and to permit persons to whom the
-Software is furnished to do so, subject to the following conditions:
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
 
-The above copyright notice and this permission notice shall be included
-in all copies or substantial portions of the Software.
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
-OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
-MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
-IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
-CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
-TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
-SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
 
-The name and trademarks of copyright holder(s) may NOT be used in
-advertising or publicity pertaining to the Software or any derivatives
-without specific, written prior permission.
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.


### PR DESCRIPTION
Approved by the copyright holders.

The historical "OpenFlow" license was adopted for harmony
with the OpenFlow project and associated software. Mininet
has always been BSD-licensed, but we're adopting the standard
license text that is recommended/approved by OSI and
automatically recognized by github.