### PR TITLE
docs: Fix a few typos

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -158,7 +158,7 @@ A simple example of configuring network and CPU bandwidth limits.
 
 This example shows how to run an `sshd` process in each host, allowing
 you to log in via `ssh`. This requires connecting the Mininet data network
-to an interface in the root namespace (generaly the control network
+to an interface in the root namespace (generally the control network
 already lives in the root namespace, so it does not need to be explicitly
 connected.)
 

--- a/mininet/node.py
+++ b/mininet/node.py
@@ -1518,7 +1518,7 @@ class Ryu( Controller ):
         """Init.
            name: name to give controller.
            ryuArgs: modules to pass to Ryu (ryu.app.simple_switch)
-           command: comand to run Ryu ('ryu run')"""
+           command: command to run Ryu ('ryu run')"""
         if isinstance( ryuArgs, ( list, tuple ) ):
             ryuArgs = ' '.join( ryuArgs )
         cargs = kwargs.pop(


### PR DESCRIPTION
There are small typos in:
- examples/README.md
- mininet/node.py

Fixes:
- Should read `generally` rather than `generaly`.
- Should read `command` rather than `comand`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md