### PR TITLE
fix: update clean.py to kill processes properly

### DIFF
--- a/mininet/clean.py
+++ b/mininet/clean.py
@@ -51,8 +51,8 @@ class Cleanup( object ):
 
         info( "*** Removing excess controllers/ofprotocols/ofdatapaths/"
               "pings/noxes\n" )
-        zombies = ( 'controller ofprotocol ofdatapath ping nox_core'
-                    'lt-nox_core ovs-openflowd ovs-controller'
+        zombies = ( 'controller ofprotocol ofdatapath ping nox_core '
+                    'lt-nox_core ovs-openflowd ovs-controller '
                     'ovs-testcontroller udpbwtest mnexec ivs ryu-manager' )
         # Note: real zombie processes can't actually be killed, since they
         # are already (un)dead. Then again,


### PR DESCRIPTION
Without extra space at the end, concatenation in `zombies` results in 4 processes not being killed