### PR TITLE
2.3.1b2

### DIFF
--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -9,48 +9,38 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        include:
-          - os: ubuntu-22.04
-            python-version: 3.x
-          - os: ubuntu-20.04
-            python-version: 3.x
-          - os: ubuntu-20.04
-            python-version: 2.x
+        os: [ubuntu-22.04, ubuntu-20.04]
+        py: [python3, python2]
     steps:
       - name: Check out Mininet source
-        uses: actions/checkout@v2
-      - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
-        with:
-          python-version: ${{ matrix.python-version }}
+        uses: actions/checkout@v3
+      - name: Install Python ${{ matrix.py }}
+        run: sudo apt install ${{ matrix.py }}
       - name: Install Mininet and base dependencies
         run: |
           sudo apt-get update -qq
           # This seems too slow unfortunately:
           # sudo apt-get upgrade -y -qq
-          PYTHON=`which python` util/install.sh -nv
+          PYTHON=${{ matrix.py }} util/install.sh -nv
       - name: Sanity test
         run: |
           export sudo="sudo env PATH=$PATH"
-          # Verify major python-version number matches python and mininet
-          export PYVER=`echo ${{ matrix.python-version }} | cut -d . -f 1`
-          export CHKVER='px import platform; print(platform.python_version())'
-          python --version |& grep " $PYVER\."
-          echo $CHKVER | $sudo mn -v output | grep " $PYVER\."
+          export PYTHON=${{ matrix.py }}
           # Newer OvS tries OpenFlow15 which crashes ovsc on ubuntu-20.04
           $sudo mn --switch ovs,protocols=OpenFlow13 --test pingall
       - name: Install test dependencies
         run: |
           sudo apt-get install -qq vlan
-          pip install pexpect
+          export PYTHON=${{ matrix.py }}
+          sudo $PYTHON -m pip install pexpect
           util/install.sh -fw
       - name: Run core tests
         run: |
           export sudo="sudo env PATH=$PATH"
-          export PYTHON=`which python`
+          export PYTHON=${{ matrix.py }}
           $sudo $PYTHON mininet/test/runner.py -v
       - name: Run examples tests (quick)
         run: |
           export sudo="sudo env PATH=$PATH"
-          export PYTHON=`which python`
+          export PYTHON=${{ matrix.py }}
           $sudo $PYTHON examples/test/runner.py -v -quick

--- a/INSTALL
+++ b/INSTALL
@@ -2,7 +2,7 @@
 Mininet Installation/Configuration Notes
 ----------------------------------------
 
-Mininet 2.3.1b1
+Mininet 2.3.1b2
 ---
 
 The supported installation methods for Mininet are 1) using a

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@ Mininet: Rapid Prototyping for Software Defined Networks
 ========================================================
 *The best way to emulate almost any network on your laptop!*
 
-Mininet 2.3.1b1
+Mininet 2.3.1b2
 
 [![Build Status][1]](https://github.com/mininet/mininet/actions)
 
@@ -70,7 +70,7 @@ Mininet includes:
 
 ### Python 3 Support
 
-- Mininet 2.3.1b1 supports Python 3 and Python 2!
+- Mininet 2.3.1b2 supports Python 3 and Python 2
 
 - You can install both the Python 3 and Python 2 versions of
 Mininet side by side, but the most recent installation will
@@ -87,9 +87,11 @@ determine which Python version is used by default by `mn`.
 
 ### Other Enhancements and Information
 
-- Support for Ubuntu 20.04 LTS (and 18.04)
+- Support for Ubuntu 22.04 LTS (and 20.04)
 
 - More reliable testing and CI via github actions
+
+- Preliminary support for cgroups v2 (and v1)
 
 - Minor bug fixes (2.3.1)
 

--- a/mininet/net.py
+++ b/mininet/net.py
@@ -109,7 +109,7 @@ from mininet.util import ( quietRun, fixLimits, numCores, ensureRoot,
 from mininet.term import cleanUpScreens, makeTerms
 
 # Mininet version: should be consistent with README and LICENSE
-VERSION = "2.3.1b1"
+VERSION = "2.3.1b2"
 
 class Mininet( object ):
     "Network emulation with hosts spawned in network namespaces."

--- a/util/install.sh
+++ b/util/install.sh
@@ -165,7 +165,7 @@ function mn_deps {
         $install gcc make socat psmisc xterm openssh-clients iperf \
             iproute telnet python-setuptools libcgroup-tools \
             ethtool help2man net-tools
-        $install ${PYPKG}-pyflakes pylint ${PYPKG}-pep8-naming  \
+        $install ${PYPKG}-pyflakes pylint ${PYPKG}-pep8-naming
             ${PYPKG}-pexpect
     elif [ "$DIST" = "SUSE LINUX"  ]; then
 		$install gcc make socat psmisc xterm openssh iperf \
@@ -190,19 +190,20 @@ function mn_deps {
 
         $install gcc make socat psmisc xterm ssh iperf telnet \
                  ethtool help2man $pf pylint $pep8 \
-                 net-tools \
-                 ${PYPKG}-pexpect ${PYPKG}-tk
+                 net-tools ${PYPKG}-tk
+
         # Install pip
         $install ${PYPKG}-pip || $install ${PYPKG}-pip-whl
         if ! ${PYTHON} -m pip -V; then
             if [ $PYTHON_VERSION == 2 ]; then
-                wget https://bootstrap.pypa.io/pip/2.6/get-pip.py
+                wget https://bootstrap.pypa.io/pip/2.7/get-pip.py
             else
                 wget https://bootstrap.pypa.io/get-pip.py
             fi
             sudo ${PYTHON} get-pip.py
             rm get-pip.py
         fi
+       ${python} -m pip install pexpect
         $install iproute2 || $install iproute
         $install cgroup-tools || $install cgroup-bin
         $install cgroupfs-mount
@@ -221,7 +222,7 @@ function mn_doc {
     if ! $install doxygen-latex; then
         echo "doxygen-latex not needed"
     fi
-    sudo pip install doxypy
+    sudo pip2 install doxypy
 }
 
 # The following will cause a full OF install, covering:


### PR DESCRIPTION
Support for Ubuntu 22.04 and 20.04.

errata:

mountCgroups has not actually been renamed, but has been changed to use cgroupfs-mount and to return the cgroups version.