### PR TITLE
Fix list of processes to kill in cleanup()

### DIFF
--- a/mininet/clean.py
+++ b/mininet/clean.py
@@ -53,9 +53,9 @@ class Cleanup( object ):
 
         info( "*** Removing excess controllers/ofprotocols/ofdatapaths/"
               "pings/noxes\n" )
-        zombies = ( 'controller ofprotocol ofdatapath ping nox_core'
-                    'lt-nox_core ovs-openflowd ovs-controller'
-                    'ovs-testcontroller udpbwtest mnexec ivs ryu-manager' )
+        zombies = ( 'controller ofprotocol ofdatapath ping nox_core '
+                    'lt-nox_core ovs-openflowd ovs-controller '
+                    'ovs-testcontroller udpbwtest mnexec ivs ryu-manager ' )
         # Note: real zombie processes can't actually be killed, since they
         # are already (un)dead. Then again,
         # you can't connect to them either, so they're mostly harmless.


### PR DESCRIPTION
The list is specified as a string, but when it was split across lines spaces were not properly added.

Probably it should actually be a list to make it more robust to adding additional process names.

For now we are adding spaces to all of the lines, so hopefully anyone who updates it will follow the pattern.

This should fix the problem of ovs-testcontroller processes not being killed.

Thanks to Rwitick Ghosh.

Closes #1164