### PR TITLE
Disable udevd to speed up tests; reinstate slow tests

### DIFF
--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -22,6 +22,11 @@ jobs:
           # This seems too slow unfortunately:
           # sudo apt-get upgrade -y -qq
           PYTHON=${{ matrix.py }} util/install.sh -nv
+      - name: Disable slow udevd
+        run: sudo systemctl stop systemd-udevd
+             systemd-udevd-kernel.socket
+             systemd-udevd-control.socket
+             || echo "couldn't disable udevd"
       - name: Sanity test
         run: |
           export sudo="sudo env PATH=$PATH"
@@ -39,8 +44,8 @@ jobs:
           export sudo="sudo env PATH=$PATH"
           export PYTHON=${{ matrix.py }}
           $sudo $PYTHON mininet/test/runner.py -v
-      - name: Run examples tests (quick)
+      - name: Run examples tests
         run: |
           export sudo="sudo env PATH=$PATH"
           export PYTHON=${{ matrix.py }}
-          $sudo $PYTHON examples/test/runner.py -v -quick
+          $sudo $PYTHON examples/test/runner.py -v


### PR DESCRIPTION
`systemd-udevd` appears to drastically increase Mininet startup time.

With `systemd-udevd` disabled,

    mn --topo single,100 --test none

takes 8s rather than 40s (31s with `NM_UNMANAGED`) on my test VM.

We need a way of disabling it globally and always for Mininet interfaces, but this is a start for github actions at least.

We execute this command before running the CI tests:

    systemctl stop systemd-udevd systemd-udevd-kernel.socket \
             systemd-udevd-control.socket

We also restore the "slow" examples tests, including `test_tree1024`.
