### PR TITLE
Unlimit cfs hosts for startup/shutdown config

### DIFF
--- a/mininet/net.py
+++ b/mininet/net.py
@@ -572,6 +572,10 @@ class Mininet( object ):
             info( controller.name + ' ' )
             controller.stop()
         info( '\n' )
+        # Unlimit cfs hosts to speed up shutdown
+        for h in self.hosts:
+            if hasattr( h, 'unlimit' ):
+                h.unlimit()
         if self.terms:
             info( '*** Stopping %i terms\n' % len( self.terms ) )
             self.stopXterms()


### PR DESCRIPTION
We defer cfs cgroup bandwidth limiting until `CPULimitedHost.configDefault()`, and we change `Mininet.stop()` to call a new `host.unlimit()` method if available.