### PR TITLE
2.3.1b4

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -2,7 +2,7 @@
 Mininet Installation/Configuration Notes
 ----------------------------------------
 
-Mininet 2.3.1b3
+Mininet 2.3.1b4
 ---
 
 The supported installation methods for Mininet are 1) using a

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@ Mininet: Rapid Prototyping for Software Defined Networks
 ========================================================
 *The best way to emulate almost any network on your laptop!*
 
-Mininet 2.3.1b3
+Mininet 2.3.1b4
 
 [![Build Status][1]](https://github.com/mininet/mininet/actions)
 
@@ -70,7 +70,7 @@ Mininet includes:
 
 ### Python 3 Support
 
-- Mininet 2.3.1b3 supports Python 3 and Python 2
+- Mininet 2.3.1b4 supports Python 3 and Python 2
 
 - You can install both the Python 3 and Python 2 versions of
 Mininet side by side, but the most recent installation will

--- a/examples/simpleperf.py
+++ b/examples/simpleperf.py
@@ -49,13 +49,19 @@ def perfTest( lossy=True ):
     net.start()
     info( "Dumping host connections\n" )
     dumpNodeConnections(net.hosts)
-    info( "Testing bandwidth between h1 and h4\n" )
+    info( "Testing bandwidth between h1 and h4 (lossy=%s)\n" % lossy )
     h1, h4 = net.getNodeByName('h1', 'h4')
     net.iperf( ( h1, h4 ), l4Type='UDP' )
+    # Debugging
+    h1.cmd('jobs')
+    h4.cmd('jobs')
     net.stop()
 
 
 if __name__ == '__main__':
     setLogLevel( 'info' )
+    # Debug for now
+    if 'testmode' in argv:
+        setLogLevel( 'debug' )
     # Prevent test_simpleperf from failing due to packet loss
     perfTest( lossy=( 'testmode' not in argv ) )

--- a/examples/test/test_simpleperf.py
+++ b/examples/test/test_simpleperf.py
@@ -19,9 +19,12 @@ class testSimplePerf( unittest.TestCase ):
         # 10 Mb/s, plus or minus 20% tolerance
         BW = 10
         TOLERANCE = .2
-        p = pexpect.spawn( 'python -m mininet.examples.simpleperf testmode' )
+        p = pexpect.spawn(
+            'python -m mininet.examples.simpleperf testmode' )
+        # Log since this seems to be failing intermittently
+        p.logfile = sys.stdout
         # check iperf results
-        p.expect( "Results: \['10M', '([\d\.]+) .bits/sec", timeout=480 )
+        p.expect( "Results: \['10M', '([\d\.]+) .bits/sec", timeout=90 )
         measuredBw = float( p.match.group( 1 ) )
         lowerBound = BW * ( 1 - TOLERANCE )
         upperBound = BW + ( 1 + TOLERANCE )
@@ -30,5 +33,5 @@ class testSimplePerf( unittest.TestCase ):
         p.wait()
 
 if __name__ == '__main__':
-    setLogLevel( 'warning' )
+    setLogLevel( 'debug' )
     unittest.main()

--- a/mininet/net.py
+++ b/mininet/net.py
@@ -109,7 +109,7 @@ from mininet.util import ( quietRun, fixLimits, numCores, ensureRoot,
 from mininet.term import cleanUpScreens, makeTerms
 
 # Mininet version: should be consistent with README and LICENSE
-VERSION = "2.3.1b3"
+VERSION = "2.3.1b4"
 
 class Mininet( object ):
     "Network emulation with hosts spawned in network namespaces."


### PR DESCRIPTION
Including changes to `mnexec -c` to reduce the number of `close()` system calls, which may help with performance in containers on Ubuntu 22.04.

Note that `systemd-udevd` also seems to be a cause of performance issues and should probably be disabled while running Mininet.