### PR TITLE
IP netns support added to hosts

### DIFF
--- a/mininet/node.py
+++ b/mininet/node.py
@@ -678,8 +678,13 @@ class Node( object ):
         pathCheck( 'mnexec', 'ifconfig', moduleName='Mininet')
 
 class Host( Node ):
-    "A host is simply a Node"
-    pass
+    "A host is simply a Node with ip netns support of format mininet:NAME ."
+    def startShell(self, mnopts=None):
+        super().startShell(mnopts)
+        self.cmdPrint('ip netns attach mininet:' + self.name + ' ' + str(self.shell.pid))
+    def terminate(self):
+        self.cmdPrint('ip netns del mininet:' + self.name)
+        return super().terminate()
 
 class CPULimitedHost( Host ):
 


### PR DESCRIPTION
The inherited functions `startShell` and `terminate` are redefined in `class Host` to attach and delete netns respectively.

The netns formed are of format `mininet:NAME`, for example, `mininet-h1` for host h1.