### PR TITLE
ip netns support added to hosts

### DIFF
--- a/mininet/node.py
+++ b/mininet/node.py
@@ -679,11 +679,14 @@ class Node( object ):
 
 class Host( Node ):
     "A host is simply a Node with ip netns support of format mininet:NAME ."
+    # pass
     def startShell(self, mnopts=None):
         super().startShell(mnopts)
-        self._popen(f'ip netns attach mininet:{self.name} {self.shell.pid}'.split(), close_fds=True)
+        # self._popen(f'ip netns attach mininet:{self.name} {self.pid}'.split(), close_fds=True)
+        self._popen(f'ln -s /proc/{self.pid}/ns/net /var/run/netns/mininet:{self.name}'.split(), close_fds=True)
     def terminate(self):
-        self._popen(f'ip netns del mininet:{self.name}'.split(), close_fds=True)
+        # self._popen(f'ip netns del mininet:{self.name}'.split(), close_fds=True)
+        self._popen(f'rm /var/run/netns/mininet:{self.name}'.split(), close_fds=True)
         return super().terminate()
 
 class CPULimitedHost( Host ):

--- a/mininet/node.py
+++ b/mininet/node.py
@@ -681,9 +681,9 @@ class Host( Node ):
     "A host is simply a Node with ip netns support of format mininet:NAME ."
     def startShell(self, mnopts=None):
         super().startShell(mnopts)
-        self.cmd('ip netns attach mininet:' + self.name + ' ' + str(self.shell.pid))
+        self._popen(f'ip netns attach mininet:{self.name} {self.shell.pid}'.split(), close_fds=True)
     def terminate(self):
-        self.cmd('ip netns del mininet:' + self.name)
+        self._popen(f'ip netns del mininet:{self.name}'.split(), close_fds=True)
         return super().terminate()
 
 class CPULimitedHost( Host ):

--- a/mininet/node.py
+++ b/mininet/node.py
@@ -678,8 +678,13 @@ class Node( object ):
         pathCheck( 'mnexec', 'ifconfig', moduleName='Mininet')
 
 class Host( Node ):
-    "A host is simply a Node"
-    pass
+    "A host is simply a Node with ip netns support of format mininet:NAME ."
+    def startShell(self, mnopts=None):
+        super().startShell(mnopts)
+        self.cmd('ip netns attach mininet:' + self.name + ' ' + str(self.shell.pid))
+    def terminate(self):
+        self.cmd('ip netns del mininet:' + self.name)
+        return super().terminate()
 
 class CPULimitedHost( Host ):
 


### PR DESCRIPTION
`class Host` in node.py is modified as follows:
- inherited function `startShell` is extended to create a symlink to `/proc/<host-pid>/nsnet` in `/var/run/netns` with name convention `mininet:<host-name>` .
- inherited function `terminate` is extended to remove the hence created symlink.

For example, `/var/run/netns/mininet:h1` for host h1.


This removes the need for extracting host-pid for running
```zsh
mnexec -da <host-pid==??> zsh -ils
```
and the other nuissance associated with it like captured KeyboardInterrupt, etc.

This also replaces the `xterm h1` and `gterm h1` in case one wishes to use any other terminal like QTerminal in Kali for this.

Now the net-namespace of h1 can be accessed as:
```zsh
ip netns exec mininet:h1 zsh -ils
```