### PR TITLE
Remove "value" parameter from setNat function

### DIFF
--- a/bin/mn
+++ b/bin/mn
@@ -211,7 +211,7 @@ class MininetRunner( object ):
             # Add or modify global variable or class
             globals()[ name ] = value
 
-    def setNat( self, _option, opt_str, value, parser ):
+    def setNat( self, _option, opt_str, parser ):
         "Set NAT option(s)"
         assert self  # satisfy pylint
         parser.values.nat = True


### PR DESCRIPTION
The "value" parameter does not seem to be used.

The variable "value" is being assigned in line 220 by calling parser.rargs.pop(0).