### PR TITLE
Fix variable assignments in function do_switch in cli.py

### DIFF
--- a/mininet/cli.py
+++ b/mininet/cli.py
@@ -397,10 +397,8 @@ class CLI( Cmd ):
         sw = args[ 0 ]
         command = args[ 1 ]
         if sw not in self.mn or self.mn.get( sw ) not in self.mn.switches:
-            error( 'invalid switch: %s\n' % args[ 1 ] )
+            error( 'invalid switch: %s\n' % command )
         else:
-            sw = args[ 0 ]
-            command = args[ 1 ]
             if command == 'start':
                 self.mn.get( sw ).start( self.mn.controllers )
             elif command == 'stop':


### PR DESCRIPTION
The variable "command" on line 398 wasn't being used, an explicit call to "args[ 1 ]" was.

The variables "sw" and "command" on lines 402 and 403 are being populated with the same values as on lines 397 and 398.