### PR TITLE
Treat other Ubuntu based distros as ubuntu

### DIFF
--- a/util/install.sh
+++ b/util/install.sh
@@ -83,6 +83,11 @@ KERNEL_HEADERS=kernel-headers-${KERNEL_NAME}
 # Treat Raspbian as Debian
 [ "$DIST" = 'Raspbian' ] && DIST='Debian'
 
+# Treat Ubuntu flavors and other Ubuntu based distros as Ubuntu
+UBUNTU_VARIANTS='Pop|elementary|Ubuntu|LinuxMint'
+echo $DIST | egrep "$UBUNTU_VARIANTS" >/dev/null && DIST='Ubuntu'
+
+
 DISTS='Ubuntu|Debian|Fedora|RedHatEnterpriseServer|SUSE LINUX'
 if ! echo $DIST | egrep "$DISTS" >/dev/null; then
     echo "Install.sh currently only supports $DISTS."


### PR DESCRIPTION
While installing utils through ``/util/install.sh``, Ubuntu based distros like Pop OS and Linux Mint throw an error

![Screenshot from 2023-12-25 21-05-07](https://github.com/mininet/mininet/assets/59135589/c12623a9-b1df-42a8-a878-22adceabfd9d)

Created a small patch so that Ubuntu based distros are treated as Ubuntu

**Tested on Pop-OS 22.04**
![Screenshot from 2023-12-25 21-05-56](https://github.com/mininet/mininet/assets/59135589/d343fb67-59bc-4ea6-abe4-05a2fa0f2bae)
