### PR TITLE
Migrate to iproute2

### DIFF
--- a/examples/hwintf.py
+++ b/examples/hwintf.py
@@ -20,7 +20,7 @@ from mininet.util import quietRun
 
 def checkIntf( intf ):
     "Make sure intf exists and is not configured."
-    config = quietRun( 'ifconfig %s 2>/dev/null' % intf, shell=True )
+    config = quietRun( 'ip addr show dev %s 2>/dev/null' % intf, shell=True )
     if not config:
         error( 'Error:', intf, 'does not exist!\n' )
         exit( 1 )

--- a/examples/linuxrouter.py
+++ b/examples/linuxrouter.py
@@ -85,7 +85,7 @@ def run():
                    waitConnected=True )  # controller is used by s1-s3
     net.start()
     info( '*** Routing Table on Router:\n' )
-    info( net[ 'r0' ].cmd( 'route' ) )
+    info( net[ 'r0' ].cmd( 'ip route' ) )
     CLI( net )
     net.stop()
 

--- a/examples/miniedit.py
+++ b/examples/miniedit.py
@@ -128,9 +128,9 @@ class CustomUserSwitch(UserSwitch):
         # Set Switch IP address
         if self.switchIP is not None:
             if not self.inNamespace:
-                self.cmd( 'ifconfig', self, self.switchIP )
+                self.cmd( 'ip addr add', self.switchIP, 'dev', self)
             else:
-                self.cmd( 'ifconfig lo', self.switchIP )
+                self.cmd( 'ip addr add', self.switchIP, 'dev lo' )
 
 class LegacyRouter( Node ):
     "Simple IP router"
@@ -172,7 +172,7 @@ class customOvs(OVSSwitch):
         OVSSwitch.start( self, controllers )
         # Set Switch IP address
         if self.switchIP is not None:
-            self.cmd( 'ifconfig', self, self.switchIP )
+            self.cmd( 'ip addr add', self.switchIP, 'dev', self)
 
 class PrefsDialog(tkSimpleDialog.Dialog):
     "Preferences dialog"
@@ -1930,27 +1930,27 @@ class MiniEdit( Frame ):
                         if self.appPrefs['switchType'] == 'user':
                             if 'switchIP' in opts:
                                 if len(opts['switchIP']) > 0:
-                                    f.write("    "+name+".cmd('ifconfig "+name+" "+opts['switchIP']+"')\n")
+                                    f.write("    "+name+".cmd('ip addr add "+opts['switchIP']+" dev "+name+"')\n")
                         elif self.appPrefs['switchType'] == 'userns':
                             if 'switchIP' in opts:
                                 if len(opts['switchIP']) > 0:
-                                    f.write("    "+name+".cmd('ifconfig lo "+opts['switchIP']+"')\n")
+                                    f.write("    "+name+".cmd('ip addr add "+opts['switchIP']+" dev lo')\n")
                         elif self.appPrefs['switchType'] == 'ovs':
                             if 'switchIP' in opts:
                                 if len(opts['switchIP']) > 0:
-                                    f.write("    "+name+".cmd('ifconfig "+name+" "+opts['switchIP']+"')\n")
+                                    f.write("    "+name+".cmd('ip addr add "+opts['switchIP']+" dev "+name+"')\n")
                     elif opts['switchType'] == 'user':
                         if 'switchIP' in opts:
                             if len(opts['switchIP']) > 0:
-                                f.write("    "+name+".cmd('ifconfig "+name+" "+opts['switchIP']+"')\n")
+                                f.write("    "+name+".cmd('ip addr add "+opts['switchIP']+" dev "+name+"')\n")
                     elif opts['switchType'] == 'userns':
                         if 'switchIP' in opts:
                             if len(opts['switchIP']) > 0:
-                                f.write("    "+name+".cmd('ifconfig lo "+opts['switchIP']+"')\n")
+                                f.write("    "+name+".cmd('ip addr add "+opts['switchIP']+" dev lo')\n")
                     elif opts['switchType'] == 'ovs':
                         if 'switchIP' in opts:
                             if len(opts['switchIP']) > 0:
-                                f.write("    "+name+".cmd('ifconfig "+name+" "+opts['switchIP']+"')\n")
+                                f.write("    "+name+".cmd('ip addr add "+opts['switchIP']+" dev "+name+"')\n")
             for widget, item in self.widgetToItem.items():
                 name = widget[ 'text' ]
                 tags = self.canvas.gettags( item )
@@ -1959,8 +1959,9 @@ class MiniEdit( Frame ):
                     # Attach vlan interfaces
                     if 'vlanInterfaces' in opts:
                         for vlanInterface in opts['vlanInterfaces']:
-                            f.write("    "+name+".cmd('vconfig add "+name+"-eth0 "+vlanInterface[1]+"')\n")
-                            f.write("    "+name+".cmd('ifconfig "+name+"-eth0."+vlanInterface[1]+" "+vlanInterface[0]+"')\n")
+                            f.write("    "+name+".cmd('ip link add link "+name+"-eth0 name %s.%s" % (name,vlanInterface[1])+" type vlan id "+vlanInterface[1]+"')\n")
+                            f.write("    "+name+".cmd('ip addr add "+vlanInterface[0]+" dev "+name+"-eth0."+vlanInterface[1]+"')\n")
+                            f.write("    "+name+".cmd('ip link set dev "+name+"-eth0."+vlanInterface[1]+" up')\n")
                     # Run User Defined Start Command
                     if 'startCommand' in opts:
                         f.write("    "+name+".cmdPrint('"+opts['startCommand']+"')\n")
@@ -2458,7 +2459,7 @@ class MiniEdit( Frame ):
             showerror(title="Error",
                       message='External interface ' +intf + ' does not exist! Skipping.')
             return False
-        ips = re.findall( r'\d+\.\d+\.\d+\.\d+', quietRun( 'ifconfig ' + intf ) )
+        ips = re.findall( r'\d+\.\d+\.\d+\.\d+', quietRun( 'ip addr show ' + intf ) )
         if ips:
             showerror(title="Error",
                       message= intf + ' has an IP address and is probably in use! Skipping.' )
@@ -2940,7 +2941,7 @@ class MiniEdit( Frame ):
                 if 'vlanInterfaces' in opts:
                     for vlanInterface in opts['vlanInterfaces']:
                         info( 'adding vlan interface '+vlanInterface[1], '\n' )
-                        newHost.cmdPrint('ifconfig '+name+'-eth0.'+vlanInterface[1]+' '+vlanInterface[0])
+                        newHost.cmdPrint('ip addr add '+vlanInterface[0]+' dev '+name+'-eth0.'+vlanInterface[1])
                 # Run User Defined Start Command
                 if 'startCommand' in opts:
                     newHost.cmdPrint(opts['startCommand'])

--- a/examples/miniedit.py
+++ b/examples/miniedit.py
@@ -139,9 +139,8 @@ class LegacyRouter( Node ):
 
     # pylint: disable=arguments-differ
     def config( self, **_params ):
-        if self.intfs:
-            self.setParam( _params, 'setIP', ip='0.0.0.0' )
-        r = Node.config( self, **_params )
+        par = {'ip':'0.0.0.0'} if self.intfs else _params
+        r = Node.config( self, **par )
         self.cmd('sysctl -w net.ipv4.ip_forward=1')
         return r
 
@@ -1959,7 +1958,7 @@ class MiniEdit( Frame ):
                     # Attach vlan interfaces
                     if 'vlanInterfaces' in opts:
                         for vlanInterface in opts['vlanInterfaces']:
-                            f.write("    "+name+".cmd('ip link add link "+name+"-eth0 name %s.%s" % (name,vlanInterface[1])+" type vlan id "+vlanInterface[1]+"')\n")
+                            f.write("    "+name+".cmd('ip link add link "+name+"-eth0 name %s-eth0.%s" % (name,vlanInterface[1])+" type vlan id "+vlanInterface[1]+"')\n")
                             f.write("    "+name+".cmd('ip addr add "+vlanInterface[0]+" dev "+name+"-eth0."+vlanInterface[1]+"')\n")
                             f.write("    "+name+".cmd('ip link set dev "+name+"-eth0."+vlanInterface[1]+" up')\n")
                     # Run User Defined Start Command
@@ -2941,7 +2940,9 @@ class MiniEdit( Frame ):
                 if 'vlanInterfaces' in opts:
                     for vlanInterface in opts['vlanInterfaces']:
                         info( 'adding vlan interface '+vlanInterface[1], '\n' )
+                        newHost.cmdPrint('ip link add link '+name+'-eth0 name %s-eth0.%s' % (name,vlanInterface[1])+' type vlan id '+vlanInterface[1])
                         newHost.cmdPrint('ip addr add '+vlanInterface[0]+' dev '+name+'-eth0.'+vlanInterface[1])
+                        newHost.cmdPrint('ip link set dev '+name+'-eth0.'+vlanInterface[1]+' up')
                 # Run User Defined Start Command
                 if 'startCommand' in opts:
                     newHost.cmdPrint(opts['startCommand'])

--- a/examples/mobility.py
+++ b/examples/mobility.py
@@ -67,14 +67,14 @@ class MobilitySwitch( OVSSwitch ):
 
     def renameIntf( self, intf, newname='' ):
         "Rename an interface (to its canonical name)"
-        intf.ifconfig( 'down' )
+        intf.cmd( 'ip link set', intf, 'down' )
         if not newname:
             newname = '%s-eth%d' % ( self.name, self.ports[ intf ] )
         intf.cmd( 'ip link set', intf, 'name', newname )
         del self.nameToIntf[ intf.name ]
         intf.name = newname
         self.nameToIntf[ intf.name ] = intf
-        intf.ifconfig( 'up' )
+        intf.cmd( 'ip link set', intf, 'up' )
 
     def moveIntf( self, intf, switch, port=None, rename=True ):
         "Move one of our interfaces to another switch"

--- a/examples/multitest.py
+++ b/examples/multitest.py
@@ -11,11 +11,11 @@ from mininet.net import Mininet
 from mininet.node import OVSKernelSwitch
 from mininet.topolib import TreeTopo
 
-def ifconfigTest( net ):
-    "Run ifconfig on all hosts in net."
+def ip_linkTest( net ):
+    "Run ip link on all hosts in net."
     hosts = net.hosts
     for host in hosts:
-        info( host.cmd( 'ifconfig' ) )
+        info( host.cmd( 'ip link' ) )
 
 
 if __name__ == '__main__':
@@ -29,8 +29,8 @@ if __name__ == '__main__':
     network.start()
     info( "*** Running ping test\n" )
     network.pingAll()
-    info( "*** Running ifconfig test\n" )
-    ifconfigTest( network )
+    info( "*** Running ip link test\n" )
+    ip_linkTest( network )
     info( "*** Starting CLI (type 'exit' to exit)\n" )
     CLI( network )
     info( "*** Stopping network\n" )

--- a/examples/scratchnetuser.py
+++ b/examples/scratchnetuser.py
@@ -51,7 +51,7 @@ def scratchNetUser( cname='controller', cargs='ptcp:' ):
 
     info( '*** Starting controller and user datapath\n' )
     controller.cmd( cname + ' ' + cargs + '&' )
-    switch.cmd( 'ifconfig lo 127.0.0.1' )
+    switch.cmd( 'ip addr add 127.0.0.1 dev lo' )
     intfs = str( sintf1 ), str( sintf2 )
     switch.cmd( 'ofdatapath -i ' + ','.join( intfs ) + ' ptcp: &' )
     switch.cmd( 'ofprotocol tcp:' + controller.IP() + ' tcp:localhost &' )

--- a/examples/scratchnetuser.py
+++ b/examples/scratchnetuser.py
@@ -51,7 +51,7 @@ def scratchNetUser( cname='controller', cargs='ptcp:' ):
 
     info( '*** Starting controller and user datapath\n' )
     controller.cmd( cname + ' ' + cargs + '&' )
-    switch.cmd( 'ip addr add 127.0.0.1 dev lo' )
+    switch.cmd( 'ip link set lo up' )
     intfs = str( sintf1 ), str( sintf2 )
     switch.cmd( 'ofdatapath -i ' + ','.join( intfs ) + ' ptcp: &' )
     switch.cmd( 'ofprotocol tcp:' + controller.IP() + ' tcp:localhost &' )

--- a/examples/sshd.py
+++ b/examples/sshd.py
@@ -45,7 +45,7 @@ def connectToRootNS( network, switch, ip, routes ):
     network.start()
     # Add routes from root ns to hosts
     for route in routes:
-        root.cmd( 'route add -net ' + route + ' dev ' + str( intf ) )
+        root.cmd( 'ip route add ' + route + ' dev ' + str( intf ) )
 
 # pylint: disable=too-many-arguments
 def sshd( network, cmd='/usr/sbin/sshd', opts='-D',

--- a/examples/test/new_test_for_iproute2/forTests/net.py
+++ b/examples/test/new_test_for_iproute2/forTests/net.py
@@ -1,0 +1,22 @@
+#!/usr/bin/env python
+from mininet.net import Mininet
+from mininet.log import setLogLevel, info
+from mininet.cli import CLI
+
+
+def net():
+
+    net = Mininet()
+    c0 = net.addController()
+    s1 = net.addSwitch( 's1' )
+    h1 = net.addHost( 'h1', ip='0.0.0.0/0' )
+    h2 = net.addHost( 'h2', ip='0.0.0.0/0' )
+    net.addLink( h1, s1 )
+    net.addLink( h2, s1 )  
+    net.start()
+    CLI( net )
+    net.stop()
+    
+if __name__ == '__main__':
+    setLogLevel( 'info' )
+    net()

--- a/examples/test/new_test_for_iproute2/runner.py
+++ b/examples/test/new_test_for_iproute2/runner.py
@@ -1,0 +1,42 @@
+#!/usr/bin/env python
+
+"""
+Run all mininet.examples tests
+ -v : verbose output
+ -quick : skip tests that take more than ~30 seconds
+"""
+
+import unittest
+import os
+import sys
+from mininet.util import ensureRoot
+from mininet.clean import cleanup
+
+class MininetTestResult( unittest.TextTestResult ):
+    def addFailure( self, test, err ):
+        super( MininetTestResult, self ).addFailure( test, err )
+        cleanup()
+    def addError( self,test, err ):
+        super( MininetTestResult, self ).addError( test, err )
+        cleanup()
+
+class MininetTestRunner( unittest.TextTestRunner ):
+    def _makeResult( self ):
+        return MininetTestResult( self.stream, self.descriptions, self.verbosity )
+
+def runTests( testDir, verbosity=1 ):
+    "discover and run all tests in testDir"
+    # ensure root and cleanup before starting tests
+    ensureRoot()
+    cleanup()
+    # discover all tests in testDir
+    testSuite = unittest.defaultTestLoader.discover( testDir )
+    # run tests
+    success = MininetTestRunner( verbosity=verbosity ).run( testSuite ).wasSuccessful()
+    sys.exit( 0 if success else 1 )
+
+if __name__ == '__main__':
+    # get the directory containing example tests
+    testDir = os.path.dirname( os.path.realpath( __file__ ) )
+    verbosity = 2 if '-v' in sys.argv else 1
+    runTests( testDir, verbosity )

--- a/examples/test/new_test_for_iproute2/test_LinuxBridge.py
+++ b/examples/test/new_test_for_iproute2/test_LinuxBridge.py
@@ -1,0 +1,94 @@
+#!/usr/bin/env python
+import re
+import unittest
+from mininet.net import Mininet
+from mininet.nodelib import LinuxBridge
+from mininet.topo import Topo
+from functools import partial
+from mininet.util import irange
+
+class RingTopo( Topo ):
+    
+    def build( self, switchNum=3, hosts=1 ):
+        if switchNum < 3:
+            raise Exception( 'The minimal number of switches to form a ring is 3.')
+        first = self.addSwitch( 's1' )
+        for hostnum in irange( 1, hosts ):
+            host = self.addHost( 'h%s' % hostnum )
+            self.addLink( first, host )
+        last = first
+        for number in irange( 2, switchNum ):
+            next = self.addSwitch( 's%s' % number )
+            for hostnum in irange( ((number-1)*hosts)+1, ((number-1)*hosts)+hosts ):
+                host = self.addHost( 'h%s' % hostnum )
+                self.addLink( next, host )
+            self.addLink( last, next )
+            last = next
+        self.addLink( last, first )
+        
+
+def NodesConnectedToSwitch( switch ):
+    result = []
+    for intf in switch.intfList():
+        if intf.link:
+            intfs = [ intf.link.intf1, intf.link.intf2 ]
+            intfs.remove( intf )
+            node = intfs[ 0 ].node
+            name = node.name
+            if name[0:1]=='h':
+                result.append(node)
+    return result
+
+class lxbrTest(unittest.TestCase):
+    
+    def setUp( self ):
+        self.regex = '(\d+) received'
+        topo = RingTopo(hosts=2)
+        switch = partial( LinuxBridge, stp=True )
+        self.net = Mininet( topo=topo, switch=switch, waitConnected=True )
+        self.net.start()
+        self.hosts = [ self.net.getNodeByName( h ) for h in topo.hosts() ]
+        self.switches = [ self.net.getNodeByName( s ) for s in topo.switches() ]
+        self.swichToStop = self.switches[ -1 ]
+        self.nodeToPing = NodesConnectedToSwitch(self.swichToStop)[-1]
+        self.pingingNode = [h for h in self.hosts if h != self.nodeToPing][0]
+
+    def testHostsAndSwitchesNum( self ):
+        self.assertFalse(len(self.switches) < 3)
+        self.assertFalse(len(self.hosts) < 2)
+
+    def testAfterSetup( self ):
+        isForwarding = 'forwarding' in self.swichToStop.cmd('bridge link show | grep \'%s state\'' % self.swichToStop.name )
+        self.assertTrue(isForwarding)
+        ping = self.pingingNode.cmd('ping -c 1 %s | grep packets' % self.nodeToPing.IP())
+        pingReceived = re.search(self.regex,ping)
+        received = pingReceived.group(1)
+        self.assertEqual(int(received),1)
+        
+    def testAfterStopLinuxBridge( self ):
+        self.swichToStop.stop(deleteIntfs=False)
+        stoppedSwitchState = self.swichToStop.cmd('bridge link show | grep \'%s state\'' % self.swichToStop.name )
+        self.assertEqual(stoppedSwitchState,'')
+        ping = self.pingingNode.cmd('ping -c 1 %s | grep packets' % self.nodeToPing.IP())
+        pingReceived = re.search(self.regex,ping)
+        received = pingReceived.group(1)
+        self.assertEqual(int(received),0)
+        
+    def testAfterStartLinuxBridge( self ):
+        self.swichToStop.start([])
+        isListening = 'listening' in self.swichToStop.cmd('bridge link show | grep \'%s state\'' % self.swichToStop.name )
+        self.assertTrue(isListening)
+        self.net.waitConnected()
+        isForwarding = 'forwarding' in self.swichToStop.cmd('bridge link show | grep \'%s state\'' % self.swichToStop.name )
+        self.assertTrue(isForwarding)
+        ping = self.pingingNode.cmd('ping -c 1 %s | grep packets' % self.nodeToPing.IP())
+        pingReceived = re.search(self.regex,ping)
+        received = pingReceived.group(1)
+        self.assertEqual(int(received),1)
+        
+        
+    def tearDown( self ):
+        self.net.stop()
+   
+if __name__ == '__main__':
+    unittest.main()    

--- a/examples/test/new_test_for_iproute2/test_link.py
+++ b/examples/test/new_test_for_iproute2/test_link.py
@@ -1,0 +1,433 @@
+#!/usr/bin/env python
+import unittest
+import json
+from mininet.net import Mininet
+from mininet.util import genRandomMac
+
+def jsonIpAddrToStrAddrInfo( jsonip ):
+    ipaddress = json.loads(jsonip)
+    return [ a for a in ipaddress[0]["addr_info"] if a["family"] == "inet" ]
+
+class TestLink(unittest.TestCase):
+    
+    def setUp( self ):
+        self.net = Mininet()
+        self.c0 = self.net.addController()
+        self.s1 = self.net.addSwitch( 's1' )
+        self.h1 = self.net.addHost( 'h1' )
+        self.h2 = self.net.addHost( 'h2' )
+        self.net.addLink( self.h1, self.s1 )
+        self.net.addLink( self.h2, self.s1 )
+        self.net.start()
+
+    def testIpLinkNoArgsNoOpts( self ):
+        iplink = self.h1.intfs[0].ipLink()
+        iplink2 = self.h1.cmd('ip link')
+        self.assertEqual(iplink,iplink2)
+
+    def testIpLinkWrongDevExeption( self ):
+        s1eth1 = self.s1.intfs[1]
+        s1eth2 = self.s1.intfs[2]
+        self.assertFalse(s1eth1.name == s1eth2.name)
+        with self.assertRaises(Exception):
+            iplink = s1eth1.ipLink('show', 'dev', s1eth2.name )
+
+    def testIpLinkArgsOpts( self ):
+        iplink = self.h1.intfs[0].ipLink('show','dev','h1-eth0',options='-br')
+        iplink2 = self.h1.cmd('ip -br link show dev h1-eth0')
+        self.assertEqual(iplink,iplink2)
+
+    def testIpLinkUpDown( self ):
+        iplink = json.loads(self.h1.cmd('ip -br -j -p link show dev h1-eth0'))
+        self.assertTrue('UP' in iplink[0]['flags'])
+        
+        self.h1.intfs[0].ipLink('set','dev','h1-eth0','down')
+        iplink = json.loads(self.h1.cmd('ip -br -j -p link show dev h1-eth0'))
+        self.assertFalse('UP' in iplink[0]['flags'])
+        
+        self.h1.intfs[0].ipLink('set','dev','h1-eth0','up')
+        iplink = json.loads(self.h1.cmd('ip -br -j -p link show dev h1-eth0'))
+        self.assertTrue('UP' in iplink[0]['flags'])
+
+    def testIpAddrNoArgsNoOpts( self ):
+        ipaddress = self.h1.intfs[0].ipAddress()
+        ipaddress2 = self.h1.cmd('ip address')
+        self.assertEqual(ipaddress,ipaddress2)
+
+    def testIpAddrWrongDevExeption( self ):
+        h1eth0 = self.h1.intfs[0]
+        with self.assertRaises(Exception):
+            ipaddress = h1eth0.ipAddress('show', 'dev', 'lo')
+
+    def testIpAddrArgsOpts( self ):
+        ipaddress = self.h1.intfs[0].ipAddress('show','dev','h1-eth0',options='-br -j')
+        ipaddress2 = self.h1.cmd('ip -br -j address show dev h1-eth0')
+        self.assertEqual(ipaddress,ipaddress2)
+
+    def testIpAddrAddDel( self ):
+        addrInfo = jsonIpAddrToStrAddrInfo(self.h1.intfs[0].ipAddress( 'show', 'dev', 'h1-eth0', options='-j -p' ))[0]
+        ipFromIpAddr = '%s/%s' % (addrInfo['local'],addrInfo['prefixlen'])
+        ipFromVar = '%s/%s' % (self.h1.intfs[0].ip, self.h1.intfs[0].prefixLen)
+        self.assertEqual(ipFromIpAddr,ipFromVar)
+        
+        self.h1.intfs[0].ipAddress('del', ipFromIpAddr ,'dev','h1-eth0')
+        addrInfo = jsonIpAddrToStrAddrInfo(self.h1.cmd( 'ip -j -p address show dev h1-eth0' ))
+        self.assertTrue(addrInfo == [])
+        
+        newip = '172.16.10.25/16'
+        self.h1.intfs[0].ipAddress('add', newip ,'dev','h1-eth0')
+        addrInfo = jsonIpAddrToStrAddrInfo(self.h1.cmd( 'ip -j -p address show dev h1-eth0' ))[0]
+        ipFromCmd = '%s/%s' % (addrInfo['local'],addrInfo['prefixlen'])
+        self.assertEqual(newip,ipFromCmd)
+        
+        oldip = newip
+        newip = '10.0.0.1/8'
+        self.h1.intfs[0].ipAddress('del', oldip ,'dev','h1-eth0')
+        self.h1.intfs[0].ipAddress('add', newip ,'dev','h1-eth0')
+
+    def testSetIPNormalCases( self ):
+        addrInfo = jsonIpAddrToStrAddrInfo(self.h2.cmd( 'ip -j -p address show dev h2-eth0' ))[0]
+        ip = addrInfo['local']
+        prefixlen = str(addrInfo['prefixlen'])
+        self.assertEqual(ip,self.h2.intfs[0].ip)
+        self.assertEqual(prefixlen,self.h2.intfs[0].prefixLen)
+        
+        newip = '192.168.0.2'
+        newPrefix = '24'
+        self.h2.intfs[0].setIP('%s/%s' % (newip,newPrefix))
+        addrInfo = jsonIpAddrToStrAddrInfo(self.h2.cmd( 'ip -j -p address show dev h2-eth0' ))[0]
+        ip = addrInfo['local']
+        prefixlen = str( addrInfo['prefixlen'] )
+        self.assertEqual( ip, self.h2.intfs[0].ip )
+        self.assertEqual( prefixlen, self.h2.intfs[0].prefixLen )
+        self.assertEqual( ip, newip )
+        self.assertEqual( prefixlen, newPrefix )
+
+        newip = '10.0.0.2'
+        newPrefix = '8'
+        self.h2.intfs[0].setIP( newip, newPrefix )
+        addrInfo = jsonIpAddrToStrAddrInfo(self.h2.cmd( 'ip -j -p address show dev h2-eth0' ))[0]
+        ip = addrInfo['local']
+        prefixlen = str( addrInfo['prefixlen'] )
+        self.assertEqual( ip, self.h2.intfs[0].ip )
+        self.assertEqual( prefixlen, self.h2.intfs[0].prefixLen )
+        self.assertEqual( ip, newip )
+        self.assertEqual( prefixlen, newPrefix )
+
+    def testSetIPToNull( self ):
+        newip = '0.0.0.0'
+        newPrefix = '8'
+        self.h2.intfs[0].setIP('%s/%s' % (newip,newPrefix))
+        addrInfo = jsonIpAddrToStrAddrInfo(self.h2.cmd( 'ip -j -p address show dev h2-eth0' ))
+        self.assertTrue(addrInfo == [])
+        self.assertEqual( None, self.h2.intfs[0].ip )
+        self.assertEqual( None, self.h2.intfs[0].prefixLen )
+        
+        newip = '10.0.0.2'
+        newPrefix = '8'
+        self.h2.intfs[0].setIP('%s/%s' % (newip,newPrefix))
+
+    def testSetIPWrongCases( self ):
+        addrInfo = jsonIpAddrToStrAddrInfo(self.h1.cmd( 'ip -j -p address show dev h1-eth0' ))[0]
+        ip = addrInfo['local']
+        prefixlen = str( addrInfo['prefixlen'] )
+        
+        with self.assertRaises(Exception):
+            self.h1.intfs[0].setIP()
+        with self.assertRaises(Exception):
+            self.h1.intfs[0].setIP(None)
+        with self.assertRaises(Exception):
+            self.h1.intfs[0].setIP('')
+        with self.assertRaises(Exception):
+            self.h1.intfs[0].setIP(None, None)
+        with self.assertRaises(Exception):
+            self.h1.intfs[0].setIP('10.0.0.56', None)
+        with self.assertRaises(Exception):
+            self.h1.intfs[0].setIP(None, '24')
+        with self.assertRaises(Exception):
+            self.h1.intfs[0].setIP('', '')
+        with self.assertRaises(Exception):
+            self.h1.intfs[0].setIP('10.1.0.108', '')
+        with self.assertRaises(Exception):
+            self.h1.intfs[0].setIP('', '16')
+        with self.assertRaises(Exception):
+            self.h1.intfs[0].setIP('192.168.10.1')
+        with self.assertRaises(Exception):
+            self.h1.intfs[0].setIP('256.5.200.34/8')
+        with self.assertRaises(Exception):
+            self.h1.intfs[0].setIP('256.5.200.34','8')
+        with self.assertRaises(Exception):
+            self.h1.intfs[0].setIP('175.256.200.34/16')
+        with self.assertRaises(Exception):
+            self.h1.intfs[0].setIP('175.256.200.34','16')
+        with self.assertRaises(Exception):
+            self.h1.intfs[0].setIP('175.55.256.34/24')
+        with self.assertRaises(Exception):
+            self.h1.intfs[0].setIP('175.55.256.34','24')
+        with self.assertRaises(Exception):
+            self.h1.intfs[0].setIP('175.55.60.256/24')
+        with self.assertRaises(Exception):
+            self.h1.intfs[0].setIP('175.55.60.256','24')
+        with self.assertRaises(Exception):
+            self.h1.intfs[0].setIP('128.99.60','24')
+        with self.assertRaises(Exception):
+            self.h1.intfs[0].setIP('128.99.60/24')
+        with self.assertRaises(Exception):
+            self.h1.intfs[0].setIP('175.55.60.56.15','24')
+        with self.assertRaises(Exception):
+            self.h1.intfs[0].setIP('175.55.60.56.15/24')
+        with self.assertRaises(Exception):
+            self.h1.intfs[0].setIP('abc.def.ghi.jkl/26')
+        with self.assertRaises(Exception):
+            self.h1.intfs[0].setIP('ijtiht+g9edcxr','26')
+        with self.assertRaises(Exception):
+            self.h1.intfs[0].setIP('192.168.10.1/33')
+        with self.assertRaises(Exception):
+            self.h1.intfs[0].setIP('192.168.10.1','33')
+        with self.assertRaises(Exception):
+            self.h1.intfs[0].setIP('192.168.10.1/k1')
+        with self.assertRaises(Exception):
+            self.h1.intfs[0].setIP('192.168.10.1','k1')
+        
+        addrInfo = jsonIpAddrToStrAddrInfo(self.h1.cmd( 'ip -j -p address show dev h1-eth0' ))[0]
+        ip2 = addrInfo['local']
+        prefixlen2 = str( addrInfo['prefixlen'] )
+        self.assertEqual( ip, self.h1.intfs[0].ip )
+        self.assertEqual( prefixlen, self.h1.intfs[0].prefixLen )
+        self.assertEqual( ip, ip2 )
+        self.assertEqual( prefixlen, prefixlen2 )
+
+    def testSetMACNormalCases( self ):
+        h1eth0mac = json.loads(self.h1.cmd( 'ip -br -j -p link show dev', self.h1.intfs[0].name ))[0]["address"]
+        self.assertEqual( h1eth0mac, self.h1.intfs[0].mac )
+        for ch in '02468ace':
+            newmac = genRandomMac(second_digit=ch)
+            self.h1.intfs[0].setMAC(newmac)
+            h1eth0mac = json.loads(self.h1.cmd( 'ip -br -j -p link show dev', self.h1.intfs[0].name ))[0]["address"]
+            self.assertEqual( h1eth0mac, self.h1.intfs[0].mac )
+            self.assertEqual( h1eth0mac, newmac )
+            
+    def testSetMACWrongCases( self ):
+        h1eth0mac = json.loads(self.h1.cmd( 'ip -br -j -p link show dev', self.h1.intfs[0].name ))[0]["address"]
+        self.assertEqual( h1eth0mac, self.h1.intfs[0].mac )
+        with self.assertRaises(Exception):
+            self.h1.intfs[0].setMAC()
+        with self.assertRaises(Exception):
+            self.h1.intfs[0].setMAC('00:00:00:00:00:00')
+        with self.assertRaises(Exception):
+            self.h1.intfs[0].setMAC('ff:ff:ff:ff:ff:ff')
+        with self.assertRaises(Exception):
+            self.h1.intfs[0].setMAC('02:050:1b:cf:b9:03')
+        with self.assertRaises(Exception):
+            self.h1.intfs[0].setMAC('d6:05:1b:cf:z9:94')
+        with self.assertRaises(Exception):
+            self.h1.intfs[0].setMAC('26:65:5d:cf:f9:')
+        with self.assertRaises(Exception):
+            self.h1.intfs[0].setMAC('c8:2b:1b:cf:f9:94:01')
+        for ch in '13579bdf':
+            newmac = genRandomMac(second_digit=ch)
+            with self.assertRaises(Exception):
+                self.h1.intfs[0].setMAC(newmac)
+
+    def testUpdateIP( self ):
+        addrInfo = jsonIpAddrToStrAddrInfo(self.h1.cmd( 'ip -j -p address show dev h1-eth0' ))[0]
+        ip = addrInfo['local']
+        prefixlen = str( addrInfo['prefixlen'] )
+        self.assertEqual( ip, self.h1.intfs[0].ip )
+        self.assertEqual( prefixlen, self.h1.intfs[0].prefixLen )
+        newip = '10.237.125.10'
+        newPrefixlen = '24'
+        self.h1.cmd('ip addr del', '%s/%s' % (ip,prefixlen) ,'dev','h1-eth0')
+        self.h1.cmd('ip addr add', '%s/%s' % (newip,newPrefixlen) ,'dev','h1-eth0')
+        addrInfo = jsonIpAddrToStrAddrInfo(self.h1.cmd( 'ip -j -p address show dev h1-eth0' ))[0]
+        ip = addrInfo['local']
+        prefixlen = str( addrInfo['prefixlen'] )
+        self.assertTrue( ip == newip )
+        self.assertTrue( prefixlen == newPrefixlen )
+        self.assertFalse( ip == self.h1.intfs[0].ip )
+        self.assertFalse( prefixlen == self.h1.intfs[0].prefixLen )
+        self.h1.intfs[0].updateIP()
+        self.assertTrue( ip == self.h1.intfs[0].ip )
+        self.assertTrue( prefixlen == self.h1.intfs[0].prefixLen )
+
+    def testUpdateMAC( self ):
+        h1eth0mac = json.loads(self.h1.cmd( 'ip -br -j -p link show dev', self.h1.intfs[0].name ))[0]["address"]
+        self.assertEqual( h1eth0mac, self.h1.intfs[0].mac )
+        newmac = genRandomMac()
+        self.h1.cmd('ip link set dev', self.h1.intfs[0].name, 'down')
+        self.h1.cmd('ip link set dev', self.h1.intfs[0].name, 'address', newmac)
+        self.h1.cmd('ip link set dev', self.h1.intfs[0].name, 'up')
+        h1eth0mac = json.loads(self.h1.cmd( 'ip -br -j -p link show dev', self.h1.intfs[0].name ))[0]["address"]
+        self.assertTrue( h1eth0mac == newmac )
+        self.assertFalse( h1eth0mac == self.h1.intfs[0].mac )
+        self.h1.intfs[0].updateMAC()
+        self.assertTrue( h1eth0mac == self.h1.intfs[0].mac )
+
+    def testUpdateAddr( self ):
+        addrInfo = jsonIpAddrToStrAddrInfo(self.h1.cmd( 'ip -j -p address show dev h1-eth0' ))[0]
+        ip = addrInfo['local']
+        prefixlen = str( addrInfo['prefixlen'] )
+        self.assertEqual( ip, self.h1.intfs[0].ip )
+        self.assertEqual( prefixlen, self.h1.intfs[0].prefixLen )
+        h1eth0mac = json.loads(self.h1.cmd( 'ip -br -j -p link show dev', self.h1.intfs[0].name ))[0]["address"]
+        self.assertEqual( h1eth0mac, self.h1.intfs[0].mac )
+        newip = '10.114.0.1'
+        newPrefixlen = '28'
+        newmac = genRandomMac()
+        self.h1.cmd('ip addr del', '%s/%s' % (ip,prefixlen) ,'dev','h1-eth0')
+        self.h1.cmd('ip addr add', '%s/%s' % (newip,newPrefixlen) ,'dev','h1-eth0')
+        self.h1.cmd('ip link set dev', self.h1.intfs[0].name, 'down')
+        self.h1.cmd('ip link set dev', self.h1.intfs[0].name, 'address', newmac)
+        self.h1.cmd('ip link set dev', self.h1.intfs[0].name, 'up')
+        addrInfo = jsonIpAddrToStrAddrInfo(self.h1.cmd( 'ip -j -p address show dev h1-eth0' ))[0]
+        ip = addrInfo['local']
+        prefixlen = str( addrInfo['prefixlen'] )
+        h1eth0mac = json.loads(self.h1.cmd( 'ip -br -j -p link show dev', self.h1.intfs[0].name ))[0]["address"]
+        self.assertTrue( ip == newip )
+        self.assertTrue( prefixlen == newPrefixlen )
+        self.assertFalse( ip == self.h1.intfs[0].ip )
+        self.assertFalse( prefixlen == self.h1.intfs[0].prefixLen )
+        self.assertTrue( h1eth0mac == newmac )
+        self.assertFalse( h1eth0mac == self.h1.intfs[0].mac )
+        self.h1.intfs[0].updateAddr()
+        self.assertTrue( ip == self.h1.intfs[0].ip )
+        self.assertTrue( prefixlen == self.h1.intfs[0].prefixLen )
+        self.assertTrue( h1eth0mac == self.h1.intfs[0].mac )
+    
+    def testIP( self ):
+        addrInfo = jsonIpAddrToStrAddrInfo(self.h1.cmd( 'ip -j -p address show dev h1-eth0' ))[0]
+        ip = addrInfo['local']
+        prefixlen = str( addrInfo['prefixlen'] )
+        self.assertEqual( ip, self.h1.intfs[0].ip )
+        self.assertEqual( ip, self.h1.intfs[0].IP() )
+        self.assertEqual( prefixlen, self.h1.intfs[0].prefixLen )
+        newip = '10.25.0.1'
+        newPrefixlen = '24'
+        self.h1.cmd('ip addr del', '%s/%s' % (ip,prefixlen) ,'dev','h1-eth0')
+        self.h1.cmd('ip addr add', '%s/%s' % (newip,newPrefixlen) ,'dev','h1-eth0')
+        addrInfo = jsonIpAddrToStrAddrInfo(self.h1.cmd( 'ip -j -p address show dev h1-eth0' ))[0]
+        ip = addrInfo['local']
+        prefixlen = str( addrInfo['prefixlen'] )
+        self.assertFalse( ip == self.h1.intfs[0].ip )
+        self.assertFalse( prefixlen == self.h1.intfs[0].prefixLen )
+        self.assertFalse( ip == self.h1.intfs[0].IP() )
+        self.assertEqual( ip, self.h1.intfs[0].IP(update=True) )
+        self.assertEqual( ip, self.h1.intfs[0].ip )
+        self.assertEqual( prefixlen, self.h1.intfs[0].prefixLen )
+        
+    def testMAC( self ):
+        h1eth0mac = json.loads(self.h1.cmd( 'ip -br -j -p link show dev', self.h1.intfs[0].name ))[0]["address"]
+        self.assertEqual( h1eth0mac, self.h1.intfs[0].mac )
+        self.assertEqual( h1eth0mac, self.h1.intfs[0].MAC() )
+        newmac = genRandomMac()
+        self.h1.cmd('ip link set dev', self.h1.intfs[0].name, 'down')
+        self.h1.cmd('ip link set dev', self.h1.intfs[0].name, 'address', newmac)
+        self.h1.cmd('ip link set dev', self.h1.intfs[0].name, 'up')
+        h1eth0mac = json.loads(self.h1.cmd( 'ip -br -j -p link show dev', self.h1.intfs[0].name ))[0]["address"]
+        self.assertTrue( h1eth0mac == newmac )
+        self.assertFalse( h1eth0mac == self.h1.intfs[0].mac )
+        self.assertFalse( h1eth0mac == self.h1.intfs[0].MAC() )
+        self.assertTrue( h1eth0mac == self.h1.intfs[0].MAC(update=True) )
+        self.assertTrue( h1eth0mac == self.h1.intfs[0].mac )
+        
+    def testIsUpDown( self ):
+        self.h1.cmd( 'ip link set', self.h1.intfs[0].name, 'down' )
+        result = self.h1.cmd( 'ip link show dev', self.h1.intfs[0].name )
+        isup = "UP" in result
+        isup2 = self.h1.intfs[0].isUp()
+        self.assertEqual( isup, False )
+        self.assertEqual( isup2, False )
+        
+    def testIsUpUp( self ):
+        isup2 = self.h1.intfs[0].isUp(setUp=True)
+        result = self.h1.cmd( 'ip link show dev', self.h1.intfs[0].name )
+        isup = "UP" in result
+        self.assertEqual( isup, True )
+        self.assertEqual( isup2, True )
+
+    def testRename( self ):
+        oldname = self.h1.intfs[0].name
+        result = self.h1.cmd( 'ip link show dev', oldname )
+        notexist = 'not exist' in result
+        self.assertEqual( notexist, False )
+        
+        newname = 'h1-net0'
+        result = self.h1.cmd( 'ip link show dev', newname )
+        notexist = 'not exist' in result
+        self.assertEqual( notexist, True )
+        
+        self.h1.intfs[0].rename(newname)
+        
+        result = self.h1.cmd( 'ip link show dev', oldname )
+        notexist = 'not exist' in result
+        self.assertEqual( notexist, True )
+        
+        result = self.h1.cmd( 'ip link show dev', newname )
+        notexist = 'not exist' in result
+        self.assertEqual( notexist, False )
+
+    def testConfigAndSetParam( self ):
+        addr = self.h1.intfs[0].config(ipAddress=['show','dev','h1-eth0',{'options':'-j -p -f inet'}])
+        addrInfo = jsonIpAddrToStrAddrInfo(addr['ipAddress'])[0]
+        ip = addrInfo['local']
+        pref = str(addrInfo['prefixlen'])
+        self.assertEqual( ip, self.h1.intfs[0].ip )
+        self.assertEqual( pref, self.h1.intfs[0].prefixLen )
+        
+        self.h1.intfs[0].config(ipAddress=['add','10.0.0.3/8','dev','h1-eth0'])
+        addr = self.h1.intfs[0].config(ipAddress=['show','dev','h1-eth0',{'options':'-j -p -f inet'}])
+        twoIpInfo = jsonIpAddrToStrAddrInfo(addr['ipAddress'])
+        
+        self.assertTrue(len(twoIpInfo) == 2)
+        
+        addrInfo = twoIpInfo[0]
+        ip = addrInfo['local']
+        pref = str(addrInfo['prefixlen'])
+        self.assertEqual( ip, self.h1.intfs[0].ip )
+        self.assertEqual( pref, self.h1.intfs[0].prefixLen )
+        
+        addrInfo2 = twoIpInfo[1]
+        ip2 = addrInfo2['local']
+        pref2 = str(addrInfo2['prefixlen'])
+        self.assertEqual( ip2, '10.0.0.3' )
+        self.assertEqual( pref2, '8' )
+        
+        result = {}
+        self.h1.intfs[0].setParam(result, 'ipAddress', **{'delip':['del','10.0.0.3/8','dev','h1-eth0']})
+        self.h1.intfs[0].setParam(result, 'ipAddress', **{'showip':['show dev h1-eth0',{'options':'-j -p -f inet'}]})
+        oneIpInfo = jsonIpAddrToStrAddrInfo(result['showip'])
+        
+        self.assertTrue(len(oneIpInfo) == 1)
+        
+        addrInfo = oneIpInfo[0]
+        ip = addrInfo['local']
+        pref = str(addrInfo['prefixlen'])
+        self.assertEqual( ip, self.h1.intfs[0].ip )
+        self.assertEqual( pref, self.h1.intfs[0].prefixLen )
+        
+        linkInfo = self.h1.intfs[0].config(ipLink=['show dev h1-eth0',{'options':'-j -p -br'}])
+        isUp = 'UP' in json.loads(linkInfo['ipLink'])[0]['flags']
+        self.assertTrue(isUp)
+        
+        self.h1.intfs[0].setParam(result, 'ipLink', **{'down':['set','dev','h1-eth0','down']})
+        self.h1.intfs[0].setParam(result, 'ipLink', **{'show':['show dev h1-eth0',{'options':'-j -p -br'}]})
+        isUp = 'UP' in json.loads(result['show'])[0]['flags']
+        self.assertFalse(isUp)
+        
+        self.h1.cmd('ip link set dev h1-eth0 up')
+        
+    def tearDown( self ):
+        self.net.stop()
+   
+if __name__ == '__main__':
+    unittest.main()        
+        
+
+
+
+
+
+
+
+
+

--- a/examples/test/new_test_for_iproute2/test_net.py
+++ b/examples/test/new_test_for_iproute2/test_net.py
@@ -1,0 +1,147 @@
+#!/usr/bin/env python
+import unittest
+import json
+from mininet.net import Mininet
+from mininet.util import pexpect
+
+class TestConfigLinkStatus(unittest.TestCase):
+    
+    def setUp( self ):
+        self.net = Mininet()
+        self.c0 = self.net.addController()
+        self.s1 = self.net.addSwitch( 's1' )
+        self.h1 = self.net.addHost( 'h1' )
+        self.h2 = self.net.addHost( 'h2' )
+        self.net.addLink( self.h1, self.s1 )
+        self.net.addLink( self.h2, self.s1 )
+        self.net.start()
+
+    def testStatusDown( self ):
+        self.net.configLinkStatus('h1','s1','down')
+        h1Result = json.loads(self.h1.cmd( 'ip -br -j -p link show dev h1-eth0' ))
+        s1Result = json.loads(self.s1.cmd( 'ip -br -j -p link show dev s1-eth1' ))
+        self.assertFalse('UP' in h1Result[0]['flags'])
+        self.assertFalse('UP' in s1Result[0]['flags'])
+
+    def testStatusUp( self ):
+        self.net.configLinkStatus('h1','s1','up')
+        h1Result = json.loads(self.h1.cmd( 'ip -br -j -p link show dev h1-eth0' ))
+        s1Result = json.loads(self.s1.cmd( 'ip -br -j -p link show dev s1-eth1' ))
+        self.assertTrue('UP' in h1Result[0]['flags'])
+        self.assertTrue('UP' in s1Result[0]['flags'])          
+        
+    def tearDown( self ):
+        self.net.stop()
+
+class TestPingAllFull(unittest.TestCase):
+
+    def setUp( self ):
+        self.net = Mininet()
+        self.c0 = self.net.addController()
+        self.s1 = self.net.addSwitch( 's1' )
+        self.h1 = self.net.addHost( 'h1', ip='0.0.0.0/0' )
+        self.h2 = self.net.addHost( 'h2', ip='0.0.0.0/0' )
+        self.net.addLink( self.h1, self.s1 )
+        self.net.addLink( self.h2, self.s1 )
+        self.net.start()
+        
+    def testPingAllFull( self ):
+        h1ip = self.h1.IP(update=True)
+        h2ip = self.h2.IP(update=True)
+        all_outputs = self.net.pingAllFull()
+        for outputs in all_outputs:
+            _, _, ping_outputs = outputs
+            sent, received, _, _, _, _ = ping_outputs
+            self.assertTrue( sent == 0 and received == 0 and h1ip is None and h2ip is None )
+        
+        h1newip = '11.0.0.1'
+        h2newip = '10.0.0.2'
+        self.h1.setIP( h1newip )
+        self.h2.setIP( h2newip )
+        h1ip = self.h1.IP()
+        h2ip = self.h2.IP()
+        all_outputs = self.net.pingAllFull()
+        for outputs in all_outputs:
+            _, _, ping_outputs = outputs
+            sent, received, _, _, _, _ = ping_outputs
+            self.assertTrue( sent == 1 and received == 0 and h1ip == h1newip and h2ip == h2newip )
+        
+        h1newip = '10.0.0.1'
+        self.h1.setIP( h1newip )
+        h1ip = self.h1.IP()
+        all_outputs = self.net.pingAllFull()
+        for outputs in all_outputs:
+            _, _, ping_outputs = outputs
+            sent, received, _, _, _, _ = ping_outputs
+            self.assertTrue( sent == 1 and received == 1 and h1ip == h1newip and h2ip == h2newip )
+            
+    def tearDown( self ):
+        self.net.stop()
+        
+class testPingAll( unittest.TestCase ):
+    
+    def setUp( self ):
+        self.prompt = 'mininet>'
+        self.opts = [ 'No packets sent','\*\*\* Results: \d{1,3}% dropped \((\d+\/\d+) received\)', self.prompt ]
+        self.net = pexpect.spawn( 'python ./forTests/net.py' )
+        self.net.expect( self.prompt )
+        
+    def testPingall( self ):
+        self.net.sendline( 'pingall' )
+        packets = None
+        result = None
+        while True:
+            index = self.net.expect( self.opts )
+            if index == 0:
+                packets = self.net.match.group( 0 )
+            elif index == 1:
+                result == self.net.match.group( 1 )
+            else:
+                break
+        
+        self.assertTrue( packets == 'No packets sent' )
+        self.assertTrue( result is None )
+        
+        self.net.sendline( 'py h1.setIP(\'11.0.0.1\')' )
+        self.net.expect( self.prompt )
+        self.net.sendline( 'py h2.setIP(\'10.0.0.2\')' )
+        self.net.expect( self.prompt )
+        self.net.sendline( 'pingall' )
+        packets = None
+        result = None
+        while True:
+            index = self.net.expect( self.opts )
+            if index == 0:
+                packets = self.net.match.group( 0 )
+            elif index == 1:
+                result = self.net.match.group( 1 ).split( '/' )
+            else:
+                break
+                
+        self.assertTrue( packets is None )
+        self.assertTrue( int(result[0]) == 0 and int(result[1]) == 2 )
+        
+        self.net.sendline( 'py h1.setIP(\'10.0.0.1\')' )
+        self.net.expect( self.prompt )
+        self.net.sendline( 'pingall' )
+        packets = None
+        result = None
+        while True:
+            index = self.net.expect( self.opts )
+            if index == 0:
+                packets = self.net.match.group( 0 )
+            elif index == 1:
+                result = self.net.match.group( 1 ).split( '/' )
+            else:
+                break
+                
+        self.assertTrue( packets is None )
+        self.assertTrue( int(result[0]) == 2 and int(result[1]) == 2 )
+
+    def tearDown( self ):
+        self.net.sendline( 'exit' )
+        self.net.wait()
+
+if __name__ == '__main__':
+    unittest.main()        
+

--- a/examples/test/new_test_for_iproute2/test_node.py
+++ b/examples/test/new_test_for_iproute2/test_node.py
@@ -1,0 +1,136 @@
+#!/usr/bin/env python
+import re
+import unittest
+import json
+from mininet.net import Mininet
+from mininet.util import genRandomMac
+
+def jsonIpAddrToStrAddrInfo( jsonip ):
+    ipaddress = json.loads(jsonip)
+    return [ a for a in ipaddress[0]["addr_info"] if a["family"] == "inet" ]
+
+class TestsetHostRoute(unittest.TestCase):
+    
+    def setUp( self ):
+        self.regex = '(\d+) received'
+        self.net = Mininet()
+        self.h1 = self.net.addHost( 'h1', ip='192.168.1.1/24' )
+        self.h2 = self.net.addHost( 'h2', ip='10.0.0.2/8' )
+        self.net.addLink( self.h1, self.h2 )
+        self.net.start()
+
+    def testsetHostRoute( self ):
+        result = self.h1.cmd('ping -c 1 %s' % self.h2.IP())
+        self.assertTrue( 'Network is unreachable' in result )
+        self.h1.setHostRoute(self.h2.IP(), self.h1.defaultIntf().name)
+        self.h2.setHostRoute(self.h1.IP(), self.h2.defaultIntf().name)
+        ping = self.h1.cmd('ping -c 1 %s | grep packets' % self.h2.IP())
+        pingReceived = re.search(self.regex,ping)
+        received = pingReceived.group(1)
+        self.assertEqual(int(received),1)
+
+    def tearDown( self ):
+        self.net.stop()
+
+class TestsetARP(unittest.TestCase):
+
+    def setUp( self ):
+        self.net = Mininet()
+        self.c0 = self.net.addController()
+        self.s1 = self.net.addSwitch( 's1' )
+        self.h1 = self.net.addHost( 'h1' )
+        self.h2 = self.net.addHost( 'h2' )
+        self.h3 = self.net.addHost( 'h3' )
+        self.net.addLink( self.h1, self.s1 )
+        self.net.addLink( self.h2, self.s1 )
+        self.net.addLink( self.h3, self.s1 )
+        self.net.start()
+
+    def testsetARP( self ):
+        h1result = self.h1.cmd('ip neigh')
+        self.assertEqual(h1result,'')
+        h2result = self.h2.cmd('ip neigh')
+        self.assertEqual(h2result,'')
+        h3result = self.h3.cmd('ip neigh')
+        self.assertEqual(h3result,'')
+        
+        self.h1.setARP(self.h2.IP(),self.h2.MAC())
+        self.h2.setARP(self.h3.IP(),self.h3.MAC(),intf='h2-eth0')
+        self.h3.setARP(self.h1.IP(),self.h1.MAC(),intf=self.h3.intfs[0])
+        
+        h1result = json.loads(self.h1.cmd('ip -j -p neigh'))
+        h2result = json.loads(self.h2.cmd('ip -j -p neigh'))
+        h3result = json.loads(self.h3.cmd('ip -j -p neigh'))
+        
+        h2ip = h1result[0]['dst']
+        h2mac = h1result[0]['lladdr']
+        self.assertEqual(self.h2.IP(),h2ip)
+        self.assertEqual(self.h2.MAC(),h2mac)
+        
+        h3ip = h2result[0]['dst']
+        h3mac = h2result[0]['lladdr']
+        self.assertEqual(self.h3.IP(),h3ip)
+        self.assertEqual(self.h3.MAC(),h3mac)
+        
+        h1ip = h3result[0]['dst']
+        h1mac = h3result[0]['lladdr']
+        self.assertEqual(self.h1.IP(),h1ip)
+        self.assertEqual(self.h1.MAC(),h1mac)
+        
+    def tearDown( self ):
+        self.net.stop()
+
+class TestIPandMAC(unittest.TestCase):
+
+    def setUp( self ):
+        self.net = Mininet()
+        self.c0 = self.net.addController()
+        self.s1 = self.net.addSwitch( 's1' )
+        self.h1 = self.net.addHost( 'h1' )
+        self.h2 = self.net.addHost( 'h2' )
+        self.net.addLink( self.h1, self.s1 )
+        self.net.addLink( self.h2, self.s1 )
+        self.net.start()
+
+    def testIP( self ):
+        addrInfo = jsonIpAddrToStrAddrInfo(self.h1.cmd( 'ip -j -p address show dev h1-eth0' ))[0]
+        ip = addrInfo['local']
+        prefixlen = str( addrInfo['prefixlen'] )
+        self.assertEqual( ip, self.h1.intfs[0].ip )
+        self.assertEqual( ip, self.h1.IP() )
+        self.assertEqual( prefixlen, self.h1.intfs[0].prefixLen )
+        newip = '10.25.0.1'
+        newPrefixlen = '24'
+        self.h1.cmd('ip addr del', '%s/%s' % (ip,prefixlen) ,'dev','h1-eth0')
+        self.h1.cmd('ip addr add', '%s/%s' % (newip,newPrefixlen) ,'dev','h1-eth0')
+        addrInfo = jsonIpAddrToStrAddrInfo(self.h1.cmd( 'ip -j -p address show dev h1-eth0' ))[0]
+        ip = addrInfo['local']
+        prefixlen = str( addrInfo['prefixlen'] )
+        self.assertFalse( ip == self.h1.intfs[0].ip )
+        self.assertFalse( prefixlen == self.h1.intfs[0].prefixLen )
+        self.assertFalse( ip == self.h1.IP() )
+        self.assertEqual( ip, self.h1.IP(intf='h1-eth0', update=True) )
+        self.assertEqual( ip, self.h1.intfs[0].ip )
+        self.assertEqual( prefixlen, self.h1.intfs[0].prefixLen )
+
+    def testMAC( self ):
+        h1eth0mac = json.loads(self.h1.cmd( 'ip -br -j -p link show dev', self.h1.intfs[0].name ))[0]["address"]
+        self.assertEqual( h1eth0mac, self.h1.intfs[0].mac )
+        self.assertEqual( h1eth0mac, self.h1.MAC() )
+        newmac = genRandomMac()
+        self.h1.cmd('ip link set dev', self.h1.intfs[0].name, 'down')
+        self.h1.cmd('ip link set dev', self.h1.intfs[0].name, 'address', newmac)
+        self.h1.cmd('ip link set dev', self.h1.intfs[0].name, 'up')
+        h1eth0mac = json.loads(self.h1.cmd( 'ip -br -j -p link show dev', self.h1.intfs[0].name ))[0]["address"]
+        self.assertTrue( h1eth0mac == newmac )
+        self.assertFalse( h1eth0mac == self.h1.intfs[0].mac )
+        self.assertFalse( h1eth0mac == self.h1.MAC() )
+        self.assertTrue( h1eth0mac == self.h1.MAC(intf='h1-eth0', update=True) )
+        self.assertTrue( h1eth0mac == self.h1.intfs[0].mac )
+        
+    def tearDown( self ):
+        self.net.stop()
+
+if __name__ == '__main__':
+    unittest.main()   
+        

--- a/examples/test/test_controlnet.py
+++ b/examples/test/test_controlnet.py
@@ -36,7 +36,7 @@ class testControlNet( unittest.TestCase ):
         self.assertEqual( count, ip )
         count += 1
         for c in [ 'c0', 'c1' ]:
-            p.sendline( '%s ifconfig %s-eth0 down' % ( c, c) )
+            p.sendline( '%s ip link set %s-eth0 down' % ( c, c) )
             p.expect( self.prompt )
             lp.expect( 'tcp:\d+\.\d+\.\d+\.(\d+):\d+: connected' )
             ip = int( lp.match.group( 1 ) )

--- a/examples/test/test_multilink.py
+++ b/examples/test/test_multilink.py
@@ -30,14 +30,14 @@ class testMultiLink( unittest.TestCase ):
         opts = [ 'h(\d)-eth(\d)', self.prompt ]
         p.expect( self.prompt )
 
-        p.sendline( 'h1 ifconfig' )
+        p.sendline( 'h1 ip link' )
         while True:
             p.expect( opts )
             if p.after == self.prompt:
                 break
             sysIntfList.append( p.after )
 
-        p.sendline( 'h2 ifconfig' )
+        p.sendline( 'h2 ip link' )
         while True:
             p.expect( opts )
             if p.after == self.prompt:

--- a/examples/test/test_vlanhost.py
+++ b/examples/test/test_vlanhost.py
@@ -37,7 +37,7 @@ class testVLANHost( unittest.TestCase ):
         percent = int( p.match.group( 1 ) ) if p.match else -1
         p.expect( self.prompt )
 
-        p.sendline( 'h1 ifconfig' )
+        p.sendline( 'h1 ip link' )
         i = p.expect( ['h1-eth0.%d' % vlan, pexpect.TIMEOUT ], timeout=2 )
         p.expect( self.prompt )
 

--- a/examples/vlanhost.py
+++ b/examples/vlanhost.py
@@ -44,11 +44,12 @@ class VLANHost( Host ):
 
         intf = self.defaultIntf()
         # remove IP from default, "physical" interface
-        self.cmd( 'ifconfig %s inet 0' % intf )
+        self.cmd( 'ip addr del', params['ip'], 'dev', intf )
         # create VLAN interface
-        self.cmd( 'vconfig add %s %d' % ( intf, vlan ) )
+        self.cmd( 'ip link add link', intf, 'name', '%s.%d' % ( intf, vlan ), 'type vlan id', vlan )
         # assign the host's IP to the VLAN interface
-        self.cmd( 'ifconfig %s.%d inet %s' % ( intf, vlan, params['ip'] ) )
+        self.cmd( 'ip addr add', params['ip'], 'dev', '%s.%d' % ( intf, vlan ) )
+        self.cmd( 'ip link set dev', '%s.%d' % ( intf, vlan ), 'up' )
         # update the intf name and host's intf map
         newName = '%s.%d' % ( intf, vlan )
         # update the (Mininet) interface to refer to VLAN interface name
@@ -117,12 +118,6 @@ if __name__ == '__main__':
     from mininet.log import setLogLevel
 
     setLogLevel( 'info' )
-
-    if not quietRun( 'which vconfig' ):
-        error( "Cannot find command 'vconfig'\nThe package",
-               "'vlan' is required in Ubuntu or Debian,",
-               "or 'vconfig' in Fedora\n" )
-        exit()
 
     if len( sys.argv ) >= 2:
         exampleAllHosts( vlan=int( sys.argv[ 1 ] ) )

--- a/mininet/link.py
+++ b/mininet/link.py
@@ -73,7 +73,7 @@ class Intf( object ):
         "Configure ourselves using ip link"
         if self.name in args:
             return self.cmd( 'ip link', *args )
-        else
+        else:
             error( "Error we can only set link options for %s" % self.name )
 
     def setIP( self, ipstr, prefixLen=None ):

--- a/mininet/net.py
+++ b/mininet/net.py
@@ -98,7 +98,7 @@ from itertools import chain, groupby
 from math import ceil
 
 from mininet.cli import CLI
-from mininet.log import info, error, output, warn, debug
+from mininet.log import info, error, output, warn
 from mininet.node import ( Node, Host, OVSKernelSwitch, DefaultController,
                            Controller )
 from mininet.nodelib import NAT
@@ -674,9 +674,8 @@ class Mininet( object ):
                     opts = ''
                     if timeout:
                         opts = '-W %s' % timeout
-                    if dest.intfs:
-                        result = node.cmd( 'LANG=C ping -c1 %s %s' %
-                                           (opts, dest.IP()) )
+                    if dest.intfs and dest.IP(update=True):
+                        result = node.cmd( 'LANG=C ping -c1 %s %s' % (opts, dest.IP(update=True)) )
                         sent, received = self._parsePing( result )
                     else:
                         sent, received = 0, 0
@@ -748,11 +747,16 @@ class Mininet( object ):
                     opts = ''
                     if timeout:
                         opts = '-W %s' % timeout
-                    result = node.cmd( 'ping -c1 %s %s' % (opts, dest.IP()) )
-                    outputs = self._parsePingFull( result )
-                    sent, received, rttmin, rttavg, rttmax, rttdev = outputs
-                    all_outputs.append( (node, dest, outputs) )
-                    output( ( '%s ' % dest.name ) if received else 'X ' )
+                    if dest.intfs and dest.IP(update=True):
+                        result = node.cmd( 'ping -c1 %s %s' % (opts, dest.IP(update=True)) )
+                        outputs = self._parsePingFull( result )
+                        sent, received, rttmin, rttavg, rttmax, rttdev = outputs
+                        all_outputs.append( (node, dest, outputs) )
+                        output( ( '%s ' % dest.name ) if received else 'X ' )
+                    else:
+                        outputs = (0, 0, 0, 0, 0, 0)
+                        all_outputs.append( (node, dest, outputs) )
+                        output('X ')
             output( '\n' )
         output( "*** Results: \n" )
         for outputs in all_outputs:
@@ -843,7 +847,6 @@ class Mininet( object ):
         cliout = client.cmd( iperfArgs + '-t %d -c ' % seconds +
                              server.IP() + ' ' + bwArgs )
         cvals = self._iperfVals( cliout, serverip )
-        debug( 'iperf client output:', cliout, cvals )
         serverout = ''
         # Wait for output from the client session
         while True:
@@ -853,7 +856,6 @@ class Mininet( object ):
             if ( svals and cvals[ 'sport' ] == svals[ 'sport' ]
                  and int( svals[ 'rate' ] ) > 0 ):
                 break
-        debug( 'iperf server output:', serverout, svals )
         server.sendInt()
         serverout += server.waitOutput()
         result = [ fmtBps( svals[ 'rate'], fmt ),

--- a/mininet/net.py
+++ b/mininet/net.py
@@ -684,7 +684,7 @@ class Mininet( object ):
                     if received > sent:
                         error( '*** Error: received too many packets' )
                         error( '%s' % result )
-                        node.cmdPrint( 'route' )
+                        node.cmdPrint( 'ip route' )
                         exit( 1 )
                     lost += sent - received
                     output( ( '%s ' % dest.name ) if received else 'X ' )
@@ -926,10 +926,10 @@ class Mininet( object ):
             if len( connections ) == 0:
                 error( 'src and dst not connected: %s %s\n' % ( src, dst) )
             for srcIntf, dstIntf in connections:
-                result = srcIntf.ifconfig( status )
+                result = srcIntf.cmd( 'ip link set dev', srcIntf, status )
                 if result:
                     error( 'link src status change failed: %s\n' % result )
-                result = dstIntf.ifconfig( status )
+                result = dstIntf.cmd( 'ip link set dev', dstIntf, status )
                 if result:
                     error( 'link dst status change failed: %s\n' % result )
 

--- a/mininet/node.py
+++ b/mininet/node.py
@@ -532,14 +532,14 @@ class Node( object ):
         """Add an ARP entry.
            ip: IP address as string
            mac: MAC address as string"""
-        result = self.cmd( 'arp', '-s', ip, mac )
+        result = self.cmd( 'ip neigh add ', ip, ' lladdr ', mac, ' dev ', self.intfs[ 0 ] )
         return result
 
     def setHostRoute( self, ip, intf ):
         """Add route to host.
            ip: IP address as dotted decimal
            intf: string, interface name"""
-        return self.cmd( 'route add -host', ip, 'dev', intf )
+        return self.cmd( 'ip route add ', ip, 'dev', intf )
 
     def setDefaultRoute( self, intf=None ):
         """Set the default route to go through intf.
@@ -623,7 +623,7 @@ class Node( object ):
         self.setParam( r, 'setIP', ip=ip )
         self.setParam( r, 'setDefaultRoute', defaultRoute=defaultRoute )
         # This should be examined
-        self.cmd( 'ifconfig lo ' + lo )
+        self.cmd( 'ip link set dev lo ' + lo)
         return r
 
     def configDefault( self, **moreParams ):
@@ -675,7 +675,7 @@ class Node( object ):
     @classmethod
     def setup( cls ):
         "Make sure our class dependencies are available"
-        pathCheck( 'mnexec', 'ifconfig', moduleName='Mininet')
+        pathCheck( 'mnexec', 'ip', moduleName='Mininet')
 
 class Host( Node ):
     "A host is simply a Node"
@@ -1165,7 +1165,7 @@ class OVSSwitch( Switch ):
     def attach( self, intf ):
         "Connect a data port"
         self.vsctl( 'add-port', self, intf )
-        self.cmd( 'ifconfig', intf, 'up' )
+        self.cmd( 'ip link set dev ', intf, 'up' )
         self.TCReapply( intf )
 
     def detach( self, intf ):
@@ -1447,7 +1447,7 @@ class Controller( Node ):
         listening = self.cmd( "echo A | telnet -e A %s %d" %
                               ( self.ip, self.port ) )
         if 'Connected' in listening:
-            servers = self.cmd( 'netstat -natp' ).split( '\n' )
+            servers = self.cmd( 'ss -natp' ).split( '\n' )
             pstr = ':%d ' % self.port
             clist = servers[ 0:1 ] + [ s for s in servers if pstr in s ]
             raise Exception( "Please shut down the controller which is"

--- a/mininet/node.py
+++ b/mininet/node.py
@@ -528,11 +528,13 @@ class Node( object ):
 
     # Routing support
 
-    def setARP( self, ip, mac ):
+    def setARP( self, ip, mac, intf=None ):
         """Add an ARP entry.
            ip: IP address as string
-           mac: MAC address as string"""
-        result = self.cmd( 'ip neigh add ', ip, ' lladdr ', mac, ' dev ', self.intfs[ 0 ] )
+           mac: MAC address as string
+           intf: interface as string or as object"""
+        intfs = self.intf(intf=intf)
+        result = self.cmd( 'ip neigh add ', ip, ' lladdr ', mac, ' dev ', intfs.name )
         return result
 
     def setHostRoute( self, ip, intf ):
@@ -568,13 +570,13 @@ class Node( object ):
            kwargs: any additional arguments for intf.setIP"""
         return self.intf( intf ).setIP( ip, prefixLen, **kwargs )
 
-    def IP( self, intf=None ):
+    def IP( self, intf=None, update=False ):
         "Return IP address of a node or specific interface."
-        return self.intf( intf ).IP()
+        return self.intf( intf ).IP(update)
 
-    def MAC( self, intf=None ):
+    def MAC( self, intf=None, update=False ):
         "Return MAC address of a node or specific interface."
-        return self.intf( intf ).MAC()
+        return self.intf( intf ).MAC(update)
 
     def intfIsUp( self, intf=None ):
         "Check if an interface is up."
@@ -612,7 +614,7 @@ class Node( object ):
         """Configure Node according to (optional) parameters:
            mac: MAC address for default interface
            ip: IP address for default interface
-           ifconfig: arbitrary interface configuration
+           defaultRoute: set defaultRoute for node
            Subclasses should override this method and call
            the parent class's config(**params)"""
         # If we were overriding this method, we would call
@@ -1472,10 +1474,10 @@ class Controller( Node ):
         self.cmd( 'wait %' + self.command )
         super( Controller, self ).stop( *args, **kwargs )
 
-    def IP( self, intf=None ):
+    def IP( self, intf=None, update=False ):
         "Return IP address of the Controller"
         if self.intfs:
-            ip = Node.IP( self, intf )
+            ip = Node.IP( self, intf, update )
         else:
             ip = self.ip
         return ip

--- a/mininet/nodelib.py
+++ b/mininet/nodelib.py
@@ -54,8 +54,8 @@ class LinuxBridge( Switch ):
         super( LinuxBridge, self ).stop( deleteIntfs )
 
     def dpctl( self, *args ):
-        "Run ip link command"
-        return self.cmd( 'ip link', *args )
+        "Run bridge command"
+        return self.cmd( 'bridge', *args )
 
     @classmethod
     def setup( cls ):

--- a/mininet/test/test_walkthrough.py
+++ b/mininet/test/test_walkthrough.py
@@ -99,34 +99,34 @@ class testWalkthrough( unittest.TestCase ):
         p.wait()
 
     def testHostCommands( self ):
-        "Test ifconfig and ps on h1 and s1"
+        "Test ip link and ps on h1 and s1"
         p = pexpect.spawn( 'mn -w' )
         p.expect( self.prompt )
         # Third pattern is a local interface beginning with 'eth' or 'en'
-        interfaces = [ r'h1-eth0[:\s]', r's1-eth1[:\s]',
-                       r'[^-](eth|en)\w*\d[:\s]', r'lo[:\s]',
+        interfaces = [ r'h1-eth0[@\s]', r's1-eth1[@\s]',
+                       r'[^-](eth|en)\w*\d[@\s]', r'lo[:\s]',
                        self.prompt ]
-        # h1 ifconfig
-        p.sendline( 'h1 ifconfig -a' )
+        # h1 ip link
+        p.sendline( 'h1 ip link' )
         ifcount = 0
         while True:
             index = p.expect( interfaces )
             if index in (0, 3):
                 ifcount += 1
             elif index == 1:
-                self.fail( 's1 interface displayed in "h1 ifconfig"' )
+                self.fail( 's1 interface displayed in "h1 ip link"' )
             elif index == 2:
-                self.fail( 'eth0 displayed in "h1 ifconfig"' )
+                self.fail( 'eth0 displayed in "h1 ip link"' )
             else:
                 break
         self.assertEqual( ifcount, 2, 'Missing interfaces on h1')
-        # s1 ifconfig
-        p.sendline( 's1 ifconfig -a' )
+        # s1 ip link
+        p.sendline( 's1 ip link' )
         ifcount = 0
         while True:
             index = p.expect( interfaces )
             if index == 0:
-                self.fail( 'h1 interface displayed in "s1 ifconfig"' )
+                self.fail( 'h1 interface displayed in "s1 ip link"' )
             elif index in (1, 2, 3):
                 ifcount += 1
             else:
@@ -225,7 +225,7 @@ class testWalkthrough( unittest.TestCase ):
         "Test TCLink bw and delay"
         p = pexpect.spawn( 'mn -w --link tc,bw=10,delay=10ms' )
         p.expect( self.prompt )
-        p.sendline( 'h1 route && ping -c1 h2' )
+        p.sendline( 'h1 ip route && ping -c1 h2' )
         # test bw
         p.expect( self.prompt )
         p.sendline( 'iperf' )
@@ -276,7 +276,7 @@ class testWalkthrough( unittest.TestCase ):
         p = pexpect.spawn( 'mn --mac' )
         p.expect( self.prompt )
         for i in range( 1, 3 ):
-            p.sendline( 'h%d ifconfig' % i )
+            p.sendline( 'h%d ip link' % i )
             p.expect( r'\s00:00:00:00:00:0%d\s' % i )
             p.expect( self.prompt )
         p.sendline( 'exit' )
@@ -303,19 +303,19 @@ class testWalkthrough( unittest.TestCase ):
         "Test running user switch in its own namespace"
         p = pexpect.spawn( 'mn --innamespace --switch user' )
         p.expect( self.prompt )
-        interfaces = [ r'h1-eth0[:\s]', r's1-eth1[:\s]',
-                       r'[^-](eth|en)\w*\d[:\s]', r'lo[:\s]',
+        interfaces = [ r'h1-eth0[@\s]', r's1-eth1[@\s]',
+                       r'[^-](eth|en)\w*\d[@\s]', r'lo[:\s]',
                        self.prompt ]
-        p.sendline( 's1 ifconfig -a' )
+        p.sendline( 's1 ip link' )
         ifcount = 0
         while True:
             index = p.expect( interfaces )
             if index in (1, 3):
                 ifcount += 1
             elif index == 0:
-                self.fail( 'h1 interface displayed in "s1 ifconfig"' )
+                self.fail( 'h1 interface displayed in "s1 ip link"' )
             elif index == 2:
-                self.fail( 'eth0 displayed in "s1 ifconfig"' )
+                self.fail( 'eth0 displayed in "s1 ip link"' )
             else:
                 break
         self.assertEqual( ifcount, 2, 'Missing interfaces on s1' )

--- a/mininet/test/test_walkthrough.py
+++ b/mininet/test/test_walkthrough.py
@@ -104,7 +104,7 @@ class testWalkthrough( unittest.TestCase ):
         p.expect( self.prompt )
         # Third pattern is a local interface beginning with 'eth' or 'en'
         interfaces = [ r'h1-eth0[@\s]', r's1-eth1[@\s]',
-                       r'[^-](eth|en)\w*\d[@\s]', r'lo[:\s]',
+                       r'[^-](eth|en)\w*\d[:\s]', r'lo[:\s]',
                        self.prompt ]
         # h1 ip link
         p.sendline( 'h1 ip link' )
@@ -304,7 +304,7 @@ class testWalkthrough( unittest.TestCase ):
         p = pexpect.spawn( 'mn --innamespace --switch user' )
         p.expect( self.prompt )
         interfaces = [ r'h1-eth0[@\s]', r's1-eth1[@\s]',
-                       r'[^-](eth|en)\w*\d[@\s]', r'lo[:\s]',
+                       r'[^-](eth|en)\w*\d[:\s]', r'lo[:\s]',
                        self.prompt ]
         p.sendline( 's1 ip link' )
         ifcount = 0

--- a/mininet/util.py
+++ b/mininet/util.py
@@ -4,6 +4,7 @@ import codecs
 import os
 import re
 import sys
+import random
 
 from collections import namedtuple
 from fcntl import fcntl, F_GETFL, F_SETFL
@@ -377,6 +378,33 @@ def macColonHex( mac ):
        mac: MAC address as unsigned int
        returns: macStr MAC colon-hex string"""
     return _colonHex( mac, 6 )
+
+def genRandomMac(valid=True, **kwargs):
+    """Generate unicast (valid) and multicast MAC adresses for testing purpose"""
+    second_digit = kwargs.get( 'second_digit' ) if kwargs and 'second_digit' in kwargs else ''
+    second_digit = second_digit if len(second_digit) == 1 and second_digit in '0123456789abcdef' else None
+    digits = [random.choice('0123456789abcdef') for _ in range(11)]
+    second_digit = second_digit if second_digit else random.choice('02468ace') if valid else random.choice('13579bdf')
+    digits.insert(1, second_digit)
+    mac_address = ':'.join(''.join(digits[i:i+2]) for i in range(0, 12, 2))
+    return mac_address
+
+def isMACValid(MAC):
+    """Validator for unicast MAC address"""
+    validMAC = re.match(r'^([0-9A-Fa-f][02468aceACE])(:[0-9A-Fa-f]{2}){5}$',MAC) and MAC != '00:00:00:00:00:00' and MAC != 'ff:ff:ff:ff:ff:ff'
+    return True if validMAC else False
+
+def isPrefixValid(prefix_str):
+    """Validator for ip address prefix"""
+    if prefix_str and ((isinstance(prefix_str, str) and prefix_str.isnumeric() and (0 <= int(prefix_str) < 33)) 
+                       or (isinstance(prefix_str, int) and 0 <= prefix_str < 33)):
+        return True
+    return False
+
+def isIpValid(ip):
+    """Validator for ip address"""
+    validip = re.match(r"^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])$",ip)
+    return True if validip else False
 
 def ipStr( ip ):
     """Generate IP address string from an unsigned int.

--- a/mininet/util.py
+++ b/mininet/util.py
@@ -704,7 +704,7 @@ def waitListening( client=None, server='127.0.0.1', port=80, timeout=None ):
     result = runCmd( cmd )
     while 'Connected' not in result:
         if 'No route' in result:
-            rtable = runCmd( 'route' )
+            rtable = runCmd( 'ip route' )
             error( 'no route to %s:\n%s' % ( server, rtable ) )
             return False
         if timeout and time >= timeout:

--- a/util/install.sh
+++ b/util/install.sh
@@ -12,6 +12,9 @@ set -o nounset
 # Get directory containing mininet folder
 MININET_DIR="$( cd -P "$( dirname "${BASH_SOURCE[0]}" )/../.." && pwd -P )"
 
+# Get mininet folder name
+MININET_FOLD="$(basename $( cd -P "$( dirname "${BASH_SOURCE[0]}" )/.." && pwd -P ))"
+
 # Set up build directory, which by default is the working directory
 #  unless the working directory is a subdirectory of mininet,
 #  in which case we use the directory containing mininet
@@ -164,7 +167,7 @@ function mn_deps {
     if [ "$DIST" = "Fedora" -o "$DIST" = "RedHatEnterpriseServer" ]; then
         $install gcc make socat psmisc xterm openssh-clients iperf \
             iproute telnet python-setuptools libcgroup-tools \
-            ethtool help2man net-tools
+            ethtool help2man
         $install ${PYPKG}-pyflakes pylint ${PYPKG}-pep8-naming \
             ${PYPKG}-pexpect
     elif [ "$DIST" = "SUSE LINUX"  ]; then
@@ -190,7 +193,7 @@ function mn_deps {
 
         $install gcc make socat psmisc xterm ssh iperf telnet \
                  ethtool help2man $pf pylint $pep8 \
-                 net-tools ${PYPKG}-tk
+                 ${PYPKG}-tk
 
         # Install pip
         $install ${PYPKG}-pip || $install ${PYPKG}-pip-whl
@@ -210,7 +213,7 @@ function mn_deps {
     fi
 
     echo "Installing Mininet core"
-    pushd $MININET_DIR/mininet
+    pushd $MININET_DIR/$MININET_FOLD
     sudo PYTHON=${PYTHON} make install
     popd
 }
@@ -246,7 +249,7 @@ function of {
     cd $BUILD_DIR/openflow
 
     # Patch controller to handle more than 16 switches
-    patch -p1 < $MININET_DIR/mininet/util/openflow-patches/controller.patch
+    patch -p1 < $MININET_DIR/$MININET_FOLD/util/openflow-patches/controller.patch
 
     # Resume the install:
     ./boot.sh
@@ -314,7 +317,7 @@ function install_wireshark {
     # Copy coloring rules: OF is white-on-blue:
     echo "Optionally installing wireshark color filters"
     mkdir -p $HOME/.wireshark
-    cp -n $MININET_DIR/mininet/util/colorfilters $HOME/.wireshark
+    cp -n $MININET_DIR/$MININET_FOLD/util/colorfilters $HOME/.wireshark
 
     echo "Checking Wireshark version"
     WSVER=`wireshark -v | egrep -o '[0-9\.]+' | head -1`
@@ -568,9 +571,9 @@ function nox {
 
     # Apply patches
     git checkout -b tutorial-destiny
-    git am $MININET_DIR/mininet/util/nox-patches/*tutorial-port-nox-destiny*.patch
+    git am $MININET_DIR/$MININET_FOLD/util/nox-patches/*tutorial-port-nox-destiny*.patch
     if [ "$DIST" = "Ubuntu" ] && version_ge $RELEASE 12.04; then
-        git am $MININET_DIR/mininet/util/nox-patches/*nox-ubuntu12-hacks.patch
+        git am $MININET_DIR/$MININET_FOLD/util/nox-patches/*nox-ubuntu12-hacks.patch
     fi
 
     # Build


### PR DESCRIPTION
This PR aims to migrate Mininet from legacy network tooling to the maintained iproute2 tools. As a result, Mininet can drop legacy dependencies like net-tools, bridge-utils, etc. (not included in major distros e.g. Ubuntu, Debian, Fedora by default since years).

I would be grateful for any feedback. This work was done by Gergely Zafir as part of his thesis, where I was the supervisor. I would be happy to contribute fixes or changes as requested in order to make this work merged.