### PR TITLE
Fix double node terminate in delNode

### DIFF
--- a/mininet/net.py
+++ b/mininet/net.py
@@ -244,7 +244,6 @@ class Mininet( object ):
                         ( self.controllers if node in self.controllers else
                           [] ) ) )
         node.stop( deleteIntfs=True )
-        node.terminate()
         nodes.remove( node )
         del self.nameToNode[ node.name ]
 


### PR DESCRIPTION
In the delNode function, the `node.stop` function is called first, and then the `node.terminate` function is called. However, the `node.terminate` function is also called once in `node.stop`, which causes `node.terminate` function to be called twice. In the case of user-defined terminate function, problems such as resource double free may occur.