### PR TITLE
Add patch for openflow to fix compile error when strlcpy is present on the system.

### DIFF
--- a/util/install.sh
+++ b/util/install.sh
@@ -248,6 +248,9 @@ function of {
     # Patch controller to handle more than 16 switches
     patch -p1 < $MININET_DIR/mininet/util/openflow-patches/controller.patch
 
+    # Patch openflow to recognize strlcpy if present on the system
+    patch -p1 < $MININET_DIR/mininet/util/openflow-patches/strlcpy.patch
+
     # Resume the install:
     ./boot.sh
     ./configure
@@ -869,7 +872,7 @@ function usage {
     printf -- ' -v: install Open (V)switch\n' >&2
     printf -- ' -V <version>: install a particular version of Open (V)switch on Ubuntu\n' >&2
     printf -- ' -w: install OpenFlow (W)ireshark dissector\n' >&2
-    printf -- ' -x: install NO(X) Classic OpenFlow controller\n' >&2    
+    printf -- ' -x: install NO(X) Classic OpenFlow controller\n' >&2
     printf -- ' -y: install R(y)u Controller\n' >&2
     printf -- ' -0: (default) -0[fx] installs OpenFlow 1.0 versions\n' >&2
     printf -- ' -3: -3[fx] installs OpenFlow 1.3 versions\n' >&2

--- a/util/openflow-patches/README
+++ b/util/openflow-patches/README
@@ -3,3 +3,5 @@ Patches for OpenFlow Reference Implementation
 controller.patch: patch controller to support up to 4096 switches (up from 16!)
 
 datapath.patch: patch to kernel datapath to compile with CONFIG_NET_NS=y
+
+strlcpy.patch: patch openflow to recognize strlcpy on the system and avoid type clashes 

--- a/util/openflow-patches/strlcpy.patch
+++ b/util/openflow-patches/strlcpy.patch
@@ -1,0 +1,32 @@
+diff --git a/lib/util.c b/lib/util.c
+index 21cc28d..ca45f18 100644
+--- a/lib/util.c
++++ b/lib/util.c
+@@ -138,6 +138,7 @@ xasprintf(const char *format, ...)
+     return s;
+ }
+
++#ifndef HAVE_STRLCPY
+ void
+ strlcpy(char *dst, const char *src, size_t size)
+ {
+@@ -148,6 +149,7 @@ strlcpy(char *dst, const char *src, size_t size)
+         dst[n_copy] = '\0';
+     }
+ }
++#endif
+
+ void
+ ofp_fatal(int err_no, const char *format, ...)
+diff --git a/lib/util.h b/lib/util.h
+index fde681f..0f8b063 100644
+--- a/lib/util.h
++++ b/lib/util.h
+@@ -34,6 +34,7 @@
+ #ifndef UTIL_H
+ #define UTIL_H 1
+
++#include <config.h>
+ #include <stdarg.h>
+ #include <stdbool.h>
+ #include <stddef.h>


### PR DESCRIPTION
This PR adds a patch to mininet to fix a build error in openflow which occurs when the host system already has `strlcpy` defined. This occurs on ubuntu 24.04 for example.

I reproduced the bug and tested the solution using this Dockerfile

```Dockerfile
FROM ubuntu:24.04

RUN apt update
RUN apt install -y sudo python3

COPY ./ /mininet
WORKDIR /mininet
RUN util/install.sh -f
```

I initially developed this patch for containernet, a fork of mininet: https://github.com/containernet/containernet/blob/master/util/openflow-patches/strlcpy.patch

I would also be fine with opening a PR on the openflow repo to fix the issue there. :)