### PR TITLE
Fix MiniEdit import issue (replace mininet.util with distutils.version)

### DIFF
--- a/examples/miniedit.py
+++ b/examples/miniedit.py
@@ -26,7 +26,8 @@ from sys import exit  # pylint: disable=redefined-builtin
 from mininet.log import info, debug, warn, setLogLevel
 from mininet.net import Mininet, VERSION
 from mininet.util import (netParse, ipAdd, quietRun,
-                          buildTopo, custom, customClass, StrictVersion )
+                          buildTopo, custom, customClass)
+from distutils.version import StrictVersion
 from mininet.term import makeTerm, cleanUpScreens
 from mininet.node import (Controller, RemoteController, NOX, OVSController,
                           CPULimitedHost, Host, Node,


### PR DESCRIPTION
Running miniedit.py(tested on Ubuntu) results in an error related to the StrictVersion module.

Fix:

- Removed the import from mininet.util.
- Imported StrictVersion from distutils.version instead.